### PR TITLE
added HTML5 shim so <= IE 8 stopped being broken

### DIFF
--- a/source/_patterns/00-atoms/00-meta/_00-head.mustache
+++ b/source/_patterns/00-atoms/00-meta/_00-head.mustache
@@ -5,11 +5,16 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width" />
 
-    <link rel="stylesheet" href="/assets/css/all.css?{{ cacheBuster }}" media="all" />
+    <link rel="stylesheet" href="../../assets/css/all.css?{{ cacheBuster }}" media="all" />
 
     <!-- Begin Pattern Lab (Required for Pattern Lab to run properly) -->
     {% pattern-lab-head %}
     <!-- End Pattern Lab -->
+
+    <!--[if lt IE 9]>
+    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js">
+    </script>
+    <![endif]-->
 
   </head>
   <body class="{{ bodyClass }}">


### PR DESCRIPTION
Also changed the link to the main stylesheet so individual patterns could be opened in the static file folder.
