### PR TITLE
fixed <= IE 8 bug in the SVG fallback.

### DIFF
--- a/assets/sass/patterns/molecules/compact-form.scss
+++ b/assets/sass/patterns/molecules/compact-form.scss
@@ -21,9 +21,9 @@
 }
 
 .compact-form__submit {
+  background: url("/assets/img/icons/arrow-forward.png");
+  background: url("/assets/img/icons/arrow-forward.svg"), linear-gradient(transparent, transparent);
   background-color: $color-primary-dark;
-  background-image: url("/assets/img/icons/arrow-forward.png");
-  background-image: url("/assets/img/icons/arrow-forward.svg"), linear-gradient(transparent, transparent);
   background-position: 50% 50%;
   background-repeat: no-repeat;
   border: none;


### PR DESCRIPTION
Turns out you have to use the background shorthand for this trick to work. Will not work with background-image
