### PR TITLE
Feature: captioned image

### DIFF
--- a/assets/sass/patterns/molecules/captioned-image.scss
+++ b/assets/sass/patterns/molecules/captioned-image.scss
@@ -1,0 +1,27 @@
+
+.captioned-image {
+  margin: 0;
+  /* max-width is a bonus here. Unlikely to be used. Not worried about support. */
+  max-width: #{get-rem-from-px(715)}rem;
+}
+
+.captioned-image__picture {
+  display: block;
+  @include margin(10, "bottom");
+}
+
+.captioned-image__image {
+  display: block;
+  width: 100%;
+}
+
+.captioned-image__caption {
+  padding: 0 6%;
+
+  p {
+    font-family: $font-secondary;
+    @include font-size(12);
+    margin: 0;
+    @include padding(0 0 5 0);
+  }
+}

--- a/source/_patterns/00-atoms/components/captioned-image.mustache
+++ b/source/_patterns/00-atoms/components/captioned-image.mustache
@@ -1,0 +1,12 @@
+
+<figure class="captioned-image">
+  <picture class="captioned-image__picture">
+    <source srcset="http://placehold.it/800/800" />
+    <img src="http://placehold.it/400/400" alt="" class="captioned-image__image" />
+  </picture>
+
+  <figcaption class="captioned-image__caption">
+    <p><strong>Many features are conserved between the mammalian nephron and planarian protonephridia.</strong></p>
+    <p>(A) Image of a young adult C. elegans and schematic depicting the twelve pairs of sensory neurons in the anterior amphid individuals carrying a virus with k deleterious mutations at its endemic equilibrium. class carrying the fewest number of deleterious mutations is defined as mutation class k = 0. Inset: variation in the basic reproductive rate of infected individuals (gray histogram) and variation in the net reproductive rate R of infected individuals (brown histogram) resulting from variation in the number of deleterious mutations carried by circulating viruses.</p>
+  </figcaption>
+</figure>


### PR DESCRIPTION
FYI. This is _not_ the pattern with the controls above it, as that, I found out, is the viewer-inline pattern. (Which is in the backlog for some reason, even though it's on the article page.)
