### PR TITLE
Normalise template field names

### DIFF
--- a/source/_patterns/00-atoms/components/picture-svg-with-fallback.mustache
+++ b/source/_patterns/00-atoms/components/picture-svg-with-fallback.mustache
@@ -3,6 +3,6 @@
   <img srcset="{{hires.path}} {{hires.width}},
                {{lores.path}} {{lores.width}}"
        src="{{lores.path}}"
-       {{#classes?}}class="{{classes?}}"{{/classes?}}
+       {{#classes}}class="{{classes}}"{{/classes}}
        alt="{{alt}}"/>
 </picture>

--- a/source/_patterns/01-molecules/components/filter-group.json
+++ b/source/_patterns/01-molecules/components/filter-group.json
@@ -1,5 +1,5 @@
 {
-  "filtergroup": {
+  "filterGroup": {
     "title": "Subject",
     "filters": [
       { "isChecked": true, "label": "Cell Biology", "results": 71 },

--- a/source/_patterns/01-molecules/components/filter-group.mustache
+++ b/source/_patterns/01-molecules/components/filter-group.mustache
@@ -1,7 +1,7 @@
 
 <div class="filter-group">
 
-  {{#filtergroup}}
+  {{#filterGroup}}
   <h4 id="filter-group__title" class="filter-group__title">{{title}}</h4>
 
   <ul class="filter-group__filters" aria-labelledby="filter-group__title">
@@ -12,6 +12,6 @@
     </li>
     {{/filters}}
   </ul>
-  {{/filtergroup}}
+  {{/filterGroup}}
 
 </div>

--- a/source/_patterns/01-molecules/components/pull-quote.json
+++ b/source/_patterns/01-molecules/components/pull-quote.json
@@ -1,5 +1,5 @@
 {
-  "pullquote": {
+  "pullQuote": {
     "quote": "Quote Incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint est laborum.",
     "cite": "<a href=\"#\">May or may not be a link</a>"
   }

--- a/source/_patterns/01-molecules/components/pull-quote.mustache
+++ b/source/_patterns/01-molecules/components/pull-quote.mustache
@@ -1,9 +1,9 @@
 <!-- Blockquotes may or may not have <p> tags surround their content. -->
 <blockquote class="pull-quote">
-  {{#pullquote}}
+  {{#pullQuote}}
   <p>
     {{quote}}
   </p>
   <cite>{{{cite}}}</cite>
-  {{/pullquote}}
+  {{/pullQuote}}
 </blockquote>

--- a/source/_patterns/01-molecules/components/sort-control.json
+++ b/source/_patterns/01-molecules/components/sort-control.json
@@ -1,5 +1,5 @@
 {
-  "sortcontrol": {
+  "sortControl": {
     "options": [
       { "option": "Date", "sorting": "ascending", "url": "?sortby=date&amp;sort=desc" },
       { "option": "Relevance", "sorting": "descending", "url": "?sortby=relevance&amp;sort=asc" },

--- a/source/_patterns/01-molecules/components/sort-control.mustache
+++ b/source/_patterns/01-molecules/components/sort-control.mustache
@@ -1,11 +1,11 @@
 
 <div class="sort-control" role="toolbar" aria-label="sorting options">
   <div class="sort-control__title">Sort by:</div>
-  {{#sortcontrol}}
+  {{#sortControl}}
   <ul class="sort-control__options">
     {{#options}}
     <li class="sort-control__option"><a href="{{url}}" class="sort-control__link sort-control__link--{{sorting}}">{{option}}</a></li>
     {{/options}}
   </ul>
-  {{/sortcontrol}}
+  {{/sortControl}}
 </div>

--- a/source/_patterns/01-molecules/navigation/main-menu.json
+++ b/source/_patterns/01-molecules/navigation/main-menu.json
@@ -1,5 +1,5 @@
 {
-  "mainmenulinks": [
+  "mainMenuLinks": [
     {
       "title": "Subjects",
       "items": [

--- a/source/_patterns/01-molecules/navigation/main-menu.mustache
+++ b/source/_patterns/01-molecules/navigation/main-menu.mustache
@@ -1,7 +1,7 @@
 
 <div class="main-menu">
   <div class="main-menu__container">
-    {{#mainmenulinks}}
+    {{#mainMenuLinks}}
     <div class="main-menu__section">
       <h4 class="main-menu__title">{{title}}</h4>
       <ul class="main-menu__list">
@@ -12,6 +12,6 @@
         {{/items}}
       </ul>
     </div>
-    {{/mainmenulinks}}
+    {{/mainMenuLinks}}
   </div>
 </div>

--- a/source/_patterns/01-molecules/navigation/nav-primary.json
+++ b/source/_patterns/01-molecules/navigation/nav-primary.json
@@ -1,15 +1,15 @@
 {
-  "navprimarylinks": [
+  "navPrimaryLinks": [
     {
       "text": "Menu",
-      "variant?": "first",
-      "textClasses?": "nav-primary__menu_text",
+      "variant": "first",
+      "textClasses": "nav-primary__menu_text",
       "path": "#",
       "alt": "Menu icon",
-      "imgs?": [
+      "imgs": [
         {
         "svg": "../../assets/img/patterns/molecules/nav-primary-menu-ic.svg",
-        "classes?": "nav-primary__menu_icon",
+        "classes": "nav-primary__menu_icon",
         "hires": {
           "path": "../../assets/img/patterns/molecules/nav-primary-menu-ic_2x.png",
           "width": "48w"
@@ -34,14 +34,14 @@
     
     {
       "text": "Search",
-      "variant?": "last",
-      "textClasses?": "visuallyhidden",
+      "variant": "last",
+      "textClasses": "visuallyhidden",
       "path": "#",
       "alt": "Search icon",
-      "imgs?": [
+      "imgs": [
         {
           "svg": "../../assets/img/patterns/molecules/nav-primary-search-ic.svg",
-          "classes?": "nav-primary__search_icon",
+          "classes": "nav-primary__search_icon",
           "hires": {
             "path": "../../assets/img/patterns/molecules/nav-primary-search-ic_2x.png",
             "width": "48w"

--- a/source/_patterns/01-molecules/navigation/nav-primary.mustache
+++ b/source/_patterns/01-molecules/navigation/nav-primary.mustache
@@ -1,15 +1,15 @@
   <nav class="nav-primary">
     <ul class="nav-primary__list clearfix">
-      {{#navprimarylinks}}
-        <li class="nav-primary__item{{#variant?}} nav-primary__item--{{variant?}}{{/variant?}}">
+      {{#navPrimaryLinks}}
+        <li class="nav-primary__item{{#variant}} nav-primary__item--{{variant}}{{/variant}}">
         <a href="{{path}}">
-          {{#imgs?}}
+          {{#imgs}}
             {{> atoms-picture-svg-with-fallback}}
-          {{/imgs?}}
-          {{#textClasses?}}<span class="{{textClasses?}}">{{text}}</span>{{/textClasses?}}
-          {{^textClasses?}}{{text}}{{/textClasses?}}
+          {{/imgs}}
+          {{#textClasses}}<span class="{{textClasses}}">{{text}}</span>{{/textClasses}}
+          {{^textClasses}}{{text}}{{/textClasses}}
         </a>
       </li>
-      {{/navprimarylinks}}
+      {{/navPrimaryLinks}}
     </ul>
   </nav>

--- a/source/_patterns/01-molecules/navigation/nav-secondary.json
+++ b/source/_patterns/01-molecules/navigation/nav-secondary.json
@@ -1,5 +1,5 @@
 {
-  "navsecondarylinks": [
+  "navSecondaryLinks": [
     {
       "text": "Careers",
       "path": "#"
@@ -18,19 +18,19 @@
     {
       "text": "Submit my research",
       "path": "#",
-      "variant?": "submit-list-item"
+      "variant": "submit-list-item"
     },
     
     {
       "text": "Alerts",
-      "variant?": "notification",
-      "textClasses?": "visuallyhidden",
+      "variant": "notification",
+      "textClasses": "visuallyhidden",
       "path": "#",
       "alt": "Notification icon",
-      "imgs?": [
+      "imgs": [
         {
           "svg": "../../assets/img/patterns/molecules/nav-secondary-notifications-ic.svg",
-          "classes?": "nav-secondary__notification-icon",
+          "classes": "nav-secondary__notification-icon",
           "hires": {
             "path": "../../assets/img/patterns/molecules/nav-secondary-notifications-ic_2x.png",
             "width": "28w"
@@ -46,14 +46,14 @@
     
     {
       "text": "Profile",
-      "variant?": "profile",
-      "textClasses?": "visuallyhidden",
+      "variant": "profile",
+      "textClasses": "visuallyhidden",
       "path": "#",
       "alt": "Profile icon",
-      "imgs?": [
+      "imgs": [
         {
         "svg": "../../assets/img/patterns/molecules/nav-secondary-profile-ic.svg",
-          "classes?": "nav-secondary__profile-icon",
+          "classes": "nav-secondary__profile-icon",
           "hires": {
           "path": "../../assets/img/patterns/molecules/nav-secondary-profile-ic_2x.png",
             "width": "28w"

--- a/source/_patterns/01-molecules/navigation/nav-secondary.mustache
+++ b/source/_patterns/01-molecules/navigation/nav-secondary.mustache
@@ -1,15 +1,15 @@
  <nav class="nav-secondary">
   <ul class="nav-secondary__list clearfix">
-   {{#navsecondarylinks}}
-    <li class="nav-secondary__item{{#variant?}} nav-secondary__item--{{variant?}}{{/variant?}}">
+   {{#navSecondaryLinks}}
+    <li class="nav-secondary__item{{#variant}} nav-secondary__item--{{variant}}{{/variant}}">
       <a href="{{path}}">
-        {{#imgs?}}
+        {{#imgs}}
           {{> atoms-picture-svg-with-fallback}}
-        {{/imgs?}}
-        {{#textClasses?}}<span class="{{textClasses?}}">{{{text}}}</span>{{/textClasses?}}
-        {{^textClasses?}}{{{text}}}{{/textClasses?}}
+        {{/imgs}}
+        {{#textClasses}}<span class="{{textClasses}}">{{{text}}}</span>{{/textClasses}}
+        {{^textClasses}}{{{text}}}{{/textClasses}}
       </a>
       </li>
-   {{/navsecondarylinks}}
+   {{/navSecondaryLinks}}
   </ul>
   </nav>

--- a/source/_patterns/01-molecules/navigation/view-selector.json
+++ b/source/_patterns/01-molecules/navigation/view-selector.json
@@ -1,5 +1,5 @@
 {
-  "jumplinks": [
+  "jumpLinks": [
     { "name": "Abstract", "url": "#" },
     { "name": "eLife digest", "url": "#" },
     { "name": "Introduction", "url": "#" },

--- a/source/_patterns/01-molecules/navigation/view-selector.mustache
+++ b/source/_patterns/01-molecules/navigation/view-selector.mustache
@@ -15,11 +15,11 @@
       <span class="view-selector__jump_links_header">Jump to</span>
 
       <ul class="view-selector__jump_links" data-behaviour="drop-down">
-        {{#jumplinks}}
+        {{#jumpLinks}}
           <li class="view-selector__jump_link_item">
             <a href="{{url}}" class="view-selector__jump_link">{{name}}</a>
           </li>
-        {{/jumplinks}}
+        {{/jumpLinks}}
       </ul>
 
     </li>

--- a/source/_patterns/02-organisms/components/filter-panel.json
+++ b/source/_patterns/02-organisms/components/filter-panel.json
@@ -1,7 +1,7 @@
 {
-  "filtergroups": [
+  "filterGroups": [
     {
-      "filtergroup": {
+      "filterGroup": {
         "title": "Subject",
         "filters": [
           { "isChecked": true, "label": "Cell Biology", "results": 71 },
@@ -17,7 +17,7 @@
     },
 
     {
-      "filtergroup": {
+      "filterGroup": {
         "title": "Content type",
         "filters": [
           { "isChecked": true, "label": "Editorial", "results": 14 },

--- a/source/_patterns/02-organisms/components/filter-panel.mustache
+++ b/source/_patterns/02-organisms/components/filter-panel.mustache
@@ -3,8 +3,8 @@
 
   <h3 class="filter-panel__title">Refine your results by</h3>
 
-  {{#filtergroups}}
+  {{#filterGroups}}
   {{> molecules-filter-group }}
-  {{/filtergroups}}
+  {{/filterGroups}}
 
 </section>

--- a/source/_patterns/02-organisms/content-headers/content-header-article-magazine-background-flat.json
+++ b/source/_patterns/02-organisms/content-headers/content-header-article-magazine-background-flat.json
@@ -1,5 +1,5 @@
 {
-  "contentheaderMagazine": {
+  "contentHeaderMagazine": {
 
     "title": "Planarian 'kidneys' go with the flow",
     

--- a/source/_patterns/02-organisms/content-headers/content-header-article-magazine-background-flat.mustache
+++ b/source/_patterns/02-organisms/content-headers/content-header-article-magazine-background-flat.mustache
@@ -1,6 +1,6 @@
 <header class="content-header content-header-article content-header-article-magazine content-header-article-magazine-background-flat">
 
-  {{#contentheaderMagazine}}
+  {{#contentHeaderMagazine}}
    <div class="content-header_top">
       <a href="#" class="content-header__subject_link">{{subject}}</a>
       <a href="#" class="content-header__download_link">
@@ -38,5 +38,5 @@
     
   <div class="content-header__ancillary"><a href="#" class="content-header__article_type_link">{{articleType}}</a> <time datetime="{{dateValue}}" class="content-header__date">{{dateText}}</time></div>
     
-  {{/contentheaderMagazine}}
+  {{/contentHeaderMagazine}}
 </header>

--- a/source/_patterns/02-organisms/content-headers/content-header-article-magazine-background-image.json
+++ b/source/_patterns/02-organisms/content-headers/content-header-article-magazine-background-image.json
@@ -1,5 +1,5 @@
 {
-  "contentheaderMagazine": {
+  "contentHeaderMagazine": {
 
     "title": "Planarian 'kidneys' go with the flow",
     

--- a/source/_patterns/02-organisms/content-headers/content-header-article-magazine-background-image.mustache
+++ b/source/_patterns/02-organisms/content-headers/content-header-article-magazine-background-image.mustache
@@ -1,6 +1,6 @@
 <header class="content-header content-header-article content-header-article-magazine content-header-article-magazine-background-image">
  
-  {{#contentheaderMagazine}}
+  {{#contentHeaderMagazine}}
   
     <!-- Buckle up.
           This style block is needed to parametise the image path used for the background image.
@@ -86,5 +86,5 @@
     
   <div class="content-header__ancillary"><a href="#" class="content-header__article_type_link">{{articleType}}</a> <time datetime="{{dateValue}}" class="content-header__date">{{dateText}}</time></div>
     
-  {{/contentheaderMagazine}}
+  {{/contentHeaderMagazine}}
 </header>

--- a/source/_patterns/02-organisms/content-headers/content-header-article-magazine.json
+++ b/source/_patterns/02-organisms/content-headers/content-header-article-magazine.json
@@ -1,5 +1,5 @@
 {
-  "contentheaderMagazine": {
+  "contentHeaderMagazine": {
 
     "title": "Planarian ‘kidneys' go with the flow",
     

--- a/source/_patterns/02-organisms/content-headers/content-header-article-magazine.mustache
+++ b/source/_patterns/02-organisms/content-headers/content-header-article-magazine.mustache
@@ -1,6 +1,6 @@
 <header class="content-header content-header-article content-header-article-magazine">
 
-  {{#contentheaderMagazine}}
+  {{#contentHeaderMagazine}}
    <div class="content-header_top">
       <a href="#" class="content-header__subject_link">{{subject}}</a>
       <a href="#" class="content-header__download_link">
@@ -38,5 +38,5 @@
     
   <div class="content-header__ancillary"><a href="#" class="content-header__article_type_link">{{articleType}}</a> <time datetime="{{dateValue}}" class="content-header__date">{{dateText}}</time></div>
     
-  {{/contentheaderMagazine}}
+  {{/contentHeaderMagazine}}
 </header>

--- a/source/_patterns/02-organisms/content-headers/content-header-article-research-readmore.json
+++ b/source/_patterns/02-organisms/content-headers/content-header-article-research-readmore.json
@@ -1,5 +1,5 @@
 {
-  "contentheaderArticle": {
+  "contentHeaderArticle": {
 
     "title": "<i>Homo naledi</i>, a new species of the genus <i>Homo</i> from the Dinaledi Chamber, South Africa",
     

--- a/source/_patterns/02-organisms/content-headers/content-header-article-research-readmore.mustache
+++ b/source/_patterns/02-organisms/content-headers/content-header-article-research-readmore.mustache
@@ -1,7 +1,7 @@
 <!-- think of content-header content-header-article as the type/sub-type of pattern, and content-header-article-research is the actual pattern. This abstraction is an experiment, we'll see how it plays. -->
 <header class="content-header content-header-article content-header-article-research content-header-article-research--readmore">
  
-  {{#contentheaderArticle}}
+  {{#contentHeaderArticle}}
 
     <a href="#" class="content-header__subject_link">{{subject}}</a>
 
@@ -21,5 +21,5 @@
     
     <div class="content-header__ancillary"><a href="#" class="content-header__article_type_link">{{articleType}}</a> <time datetime="{{dateValue}}" class="content-header__date">{{dateText}}</time></div>
     
-  {{/contentheaderArticle}}
+  {{/contentHeaderArticle}}
 </header>

--- a/source/_patterns/02-organisms/content-headers/content-header-article-research.json
+++ b/source/_patterns/02-organisms/content-headers/content-header-article-research.json
@@ -1,5 +1,5 @@
 {
-  "contentheaderArticle": {
+  "contentHeaderArticle": {
 
     "title": "<i>Homo naledi</i>, a new species of the genus <i>Homo</i> from the Dinaledi Chamber, South Africa",
     

--- a/source/_patterns/02-organisms/content-headers/content-header-article-research.mustache
+++ b/source/_patterns/02-organisms/content-headers/content-header-article-research.mustache
@@ -1,7 +1,7 @@
 <!-- think of content-header content-header-article as the type/sub-type of pattern, and content-header-article-research is the actual pattern. This abstraction is an experiment, we'll see how it plays. -->
 <header class="content-header content-header-article content-header-article-research">
  
-  {{#contentheaderArticle}}
+  {{#contentHeaderArticle}}
 
    <div class="content-header_top">
       <a href="#" class="content-header__subject_link">{{subject}}</a>
@@ -50,5 +50,5 @@
     
     <div class="content-header__ancillary"><a href="#" class="content-header__article_type_link">{{articleType}}</a> <time datetime="{{dateValue}}" class="content-header__date">{{dateText}}</time></div>
     
-  {{/contentheaderArticle}}
+  {{/contentHeaderArticle}}
 </header>

--- a/source/_patterns/02-organisms/content-headers/content-header-basic--background-flat.json
+++ b/source/_patterns/02-organisms/content-headers/content-header-basic--background-flat.json
@@ -1,5 +1,5 @@
 {
-  "contentheaderBasic": {
+  "contentHeaderBasic": {
     
     "title": "About <i>eLife</i>",
     

--- a/source/_patterns/02-organisms/content-headers/content-header-basic--background-flat.mustache
+++ b/source/_patterns/02-organisms/content-headers/content-header-basic--background-flat.mustache
@@ -1,6 +1,6 @@
 <header class="content-header content-header-nonarticle content-header-nonarticle--background-flat">
 
-  {{#contentheaderBasic}}
+  {{#contentHeaderBasic}}
   <div class="content-header__inner">
     <div class="content-header__hgroup">
       <h2 class="content-header__title {{titleClass}}">{{{title}}}</h2>
@@ -8,6 +8,6 @@
     </div>
   </div> <!--  /.content-header__inner -->
     
-  {{/contentheaderBasic}}
+  {{/contentHeaderBasic}}
   <div class="content-header__bottom_line"></div>
 </header>

--- a/source/_patterns/02-organisms/content-headers/content-header-basic-background-image.json
+++ b/source/_patterns/02-organisms/content-headers/content-header-basic-background-image.json
@@ -1,5 +1,5 @@
 {
-  "contentheaderBasic": {
+  "contentHeaderBasic": {
     
     "title": "About <i>eLife</i>",
     

--- a/source/_patterns/02-organisms/content-headers/content-header-basic-background-image.mustache
+++ b/source/_patterns/02-organisms/content-headers/content-header-basic-background-image.mustache
@@ -1,6 +1,6 @@
 <header class="content-header content-header-nonarticle content-header-nonarticle-background-image">
 
-  {{#contentheaderBasic}}
+  {{#contentHeaderBasic}}
 
   <style type="text/css">
     @media only all and (-webkit-min-device-pixel-ratio: 2) {
@@ -48,6 +48,6 @@
     </div>
   </div> <!--  /.content-header__inner -->
     
-  {{/contentheaderBasic}}
+  {{/contentHeaderBasic}}
   <div class="content-header__bottom_line"></div>
 </header>

--- a/source/_patterns/02-organisms/content-headers/content-header-basic.json
+++ b/source/_patterns/02-organisms/content-headers/content-header-basic.json
@@ -1,5 +1,5 @@
 {
-  "contentheaderBasic": {
+  "contentHeaderBasic": {
     
     "title": "About <i>eLife</i>",
     

--- a/source/_patterns/02-organisms/content-headers/content-header-basic.mustache
+++ b/source/_patterns/02-organisms/content-headers/content-header-basic.mustache
@@ -1,6 +1,6 @@
 <header class="content-header content-header-nonarticle">
 
-  {{#contentheaderBasic}}
+  {{#contentHeaderBasic}}
   <div class="content-header__inner">
     <div class="content-header__hgroup">
       <h2 class="content-header__title {{titleClass}}">{{{title}}}</h2>
@@ -8,6 +8,6 @@
     </div>
   </div> <!--  /.content-header__inner -->
     
-  {{/contentheaderBasic}}
+  {{/contentHeaderBasic}}
   <div class="content-header__bottom_line"></div>
 </header>

--- a/source/_patterns/02-organisms/global/footer.json
+++ b/source/_patterns/02-organisms/global/footer.json
@@ -1,5 +1,5 @@
 {
-  "mainmenulinks": [
+  "mainMenuLinks": [
     {
       "title": "Subjects",
       "items": [
@@ -31,7 +31,7 @@
     }
   ],
 
-  "footermenulinks": [
+  "footerMenuLinks": [
     { "name": "About", "url": "#" },
     { "name": "Who we work with", "url": "#" },
     { "name": "Alerts", "url": "#" },

--- a/source/_patterns/02-organisms/global/footer.mustache
+++ b/source/_patterns/02-organisms/global/footer.mustache
@@ -11,11 +11,11 @@
 
       <nav class="footer-navigation">
         <ul class="footer-navigation__list">
-          {{#footermenulinks}}
+          {{#footerMenuLinks}}
           <li class="footer-navigation__list_item">
             <a href="{{url}}" class="footer-navigation__list_link">{{name}}</a>
           </li>
-          {{/footermenulinks}}
+          {{/footerMenuLinks}}
         </ul>
       </nav>
 

--- a/source/_patterns/02-organisms/global/header.json
+++ b/source/_patterns/02-organisms/global/header.json
@@ -1,15 +1,15 @@
 {
-  "navprimarylinks": [
+  "navPrimaryLinks": [
     {
       "text": "Menu",
-      "variant?": "first",
-      "textClasses?": "nav-primary__menu_text",
+      "variant": "first",
+      "textClasses": "nav-primary__menu_text",
       "path": "#",
       "alt": "Menu icon",
-      "imgs?": [
+      "imgs": [
         {
         "svg": "../../assets/img/patterns/molecules/nav-primary-menu-ic.svg",
-        "classes?": "nav-primary__menu_icon",
+        "classes": "nav-primary__menu_icon",
         "hires": {
           "path": "../../assets/img/patterns/molecules/nav-primary-menu-ic_2x.png",
           "width": "48w"
@@ -34,14 +34,14 @@
     
     {
       "text": "Search",
-      "variant?": "last",
-      "textClasses?": "visuallyhidden",
+      "variant": "last",
+      "textClasses": "visuallyhidden",
       "path": "#",
       "alt": "Search icon",
-      "imgs?": [
+      "imgs": [
         {
           "svg": "../../assets/img/patterns/molecules/nav-primary-search-ic.svg",
-          "classes?": "nav-primary__search_icon",
+          "classes": "nav-primary__search_icon",
           "hires": {
             "path": "../../assets/img/patterns/molecules/nav-primary-search-ic_2x.png",
             "width": "48w"
@@ -55,7 +55,7 @@
     }
   ],
     
-  "navsecondarylinks": [
+  "navSecondaryLinks": [
     {
       "text": "Careers",
       "path": "#"
@@ -74,19 +74,19 @@
     {
       "text": "Submit my research",
       "path": "#",
-      "variant?": "submit-list-item"
+      "variant": "submit-list-item"
     },
     
     {
       "text": "Alerts",
-      "variant?": "notification",
-      "textClasses?": "visuallyhidden",
+      "variant": "notification",
+      "textClasses": "visuallyhidden",
       "path": "#",
       "alt": "Notification icon",
-      "imgs?": [
+      "imgs": [
         {
           "svg": "../../assets/img/patterns/molecules/nav-secondary-notifications-ic.svg",
-          "classes?": "nav-secondary__notification-icon",
+          "classes": "nav-secondary__notification-icon",
           "hires": {
             "path": "../../assets/img/patterns/molecules/nav-secondary-notifications-ic_2x.png",
             "width": "28w"
@@ -102,14 +102,14 @@
     
     {
       "text": "Profile",
-      "variant?": "profile",
-      "textClasses?": "visuallyhidden",
+      "variant": "profile",
+      "textClasses": "visuallyhidden",
       "path": "#",
       "alt": "Profile icon",
-      "imgs?": [
+      "imgs": [
         {
         "svg": "../../assets/img/patterns/molecules/nav-secondary-profile-ic.svg",
-          "classes?": "nav-secondary__profile-icon",
+          "classes": "nav-secondary__profile-icon",
           "hires": {
           "path": "../../assets/img/patterns/molecules/nav-secondary-profile-ic_2x.png",
             "width": "28w"

--- a/source/_patterns/03-templates/grid-test.json
+++ b/source/_patterns/03-templates/grid-test.json
@@ -2,14 +2,14 @@
   "navprimarylinks": [
     {
       "text": "Menu",
-      "variant?": "first",
-      "textClasses?": "nav-primary__menu_text",
+      "variant": "first",
+      "textClasses": "nav-primary__menu_text",
       "path": "#",
       "alt": "Menu icon",
-      "imgs?": [
+      "imgs": [
         {
         "svg": "../../assets/img/patterns/molecules/nav-primary-menu-ic.svg",
-        "classes?": "nav-primary__menu_icon",
+        "classes": "nav-primary__menu_icon",
         "hires": {
           "path": "../../assets/img/patterns/molecules/nav-primary-menu-ic_2x.png",
           "width": "48w"
@@ -34,14 +34,14 @@
 
     {
       "text": "Search",
-      "variant?": "last",
-      "textClasses?": "visuallyhidden",
+      "variant": "last",
+      "textClasses": "visuallyhidden",
       "path": "#",
       "alt": "Search icon",
-      "imgs?": [
+      "imgs": [
         {
           "svg": "../../assets/img/patterns/molecules/nav-primary-search-ic.svg",
-          "classes?": "nav-primary__search_icon",
+          "classes": "nav-primary__search_icon",
           "hires": {
             "path": "../../assets/img/patterns/molecules/nav-primary-search-ic_2x.png",
             "width": "48w"
@@ -74,19 +74,19 @@
     {
       "text": "Submit my research",
       "path": "#",
-      "variant?": "submit-list-item"
+      "variant": "submit-list-item"
     },
 
     {
       "text": "Alerts",
-      "variant?": "notification",
-      "textClasses?": "visuallyhidden",
+      "variant": "notification",
+      "textClasses": "visuallyhidden",
       "path": "#",
       "alt": "Notification icon",
-      "imgs?": [
+      "imgs": [
         {
           "svg": "../../assets/img/patterns/molecules/nav-secondary-notifications-ic.svg",
-          "classes?": "nav-secondary__notification-icon",
+          "classes": "nav-secondary__notification-icon",
           "hires": {
             "path": "../../assets/img/patterns/molecules/nav-secondary-notifications-ic_2x.png",
             "width": "28w"
@@ -102,14 +102,14 @@
 
     {
       "text": "Profile",
-      "variant?": "profile",
-      "textClasses?": "visuallyhidden",
+      "variant": "profile",
+      "textClasses": "visuallyhidden",
       "path": "#",
       "alt": "Profile icon",
-      "imgs?": [
+      "imgs": [
         {
         "svg": "../../assets/img/patterns/molecules/nav-secondary-profile-ic.svg",
-          "classes?": "nav-secondary__profile-icon",
+          "classes": "nav-secondary__profile-icon",
           "hires": {
           "path": "../../assets/img/patterns/molecules/nav-secondary-profile-ic_2x.png",
             "width": "28w"

--- a/source/_patterns/04-pages/article.json
+++ b/source/_patterns/04-pages/article.json
@@ -2,14 +2,14 @@
   "navprimarylinks": [
     {
       "text": "Menu",
-      "variant?": "first",
-      "textClasses?": "nav-primary__menu_text",
+      "variant": "first",
+      "textClasses": "nav-primary__menu_text",
       "path": "#",
       "alt": "Menu icon",
-      "imgs?": [
+      "imgs": [
         {
         "svg": "../../assets/img/patterns/molecules/nav-primary-menu-ic.svg",
-        "classes?": "nav-primary__menu_icon",
+        "classes": "nav-primary__menu_icon",
         "hires": {
           "path": "../../assets/img/patterns/molecules/nav-primary-menu-ic_2x.png",
           "width": "48w"
@@ -34,14 +34,14 @@
 
     {
       "text": "Search",
-      "variant?": "last",
-      "textClasses?": "visuallyhidden",
+      "variant": "last",
+      "textClasses": "visuallyhidden",
       "path": "#",
       "alt": "Search icon",
-      "imgs?": [
+      "imgs": [
         {
           "svg": "../../assets/img/patterns/molecules/nav-primary-search-ic.svg",
-          "classes?": "nav-primary__search_icon",
+          "classes": "nav-primary__search_icon",
           "hires": {
             "path": "../../assets/img/patterns/molecules/nav-primary-search-ic_2x.png",
             "width": "48w"
@@ -74,19 +74,19 @@
     {
       "text": "Submit my research",
       "path": "#",
-      "variant?": "submit-list-item"
+      "variant": "submit-list-item"
     },
 
     {
       "text": "Alerts",
-      "variant?": "notification",
-      "textClasses?": "visuallyhidden",
+      "variant": "notification",
+      "textClasses": "visuallyhidden",
       "path": "#",
       "alt": "Notification icon",
-      "imgs?": [
+      "imgs": [
         {
           "svg": "../../assets/img/patterns/molecules/nav-secondary-notifications-ic.svg",
-          "classes?": "nav-secondary__notification-icon",
+          "classes": "nav-secondary__notification-icon",
           "hires": {
             "path": "../../assets/img/patterns/molecules/nav-secondary-notifications-ic_2x.png",
             "width": "28w"
@@ -102,14 +102,14 @@
 
     {
       "text": "Profile",
-      "variant?": "profile",
-      "textClasses?": "visuallyhidden",
+      "variant": "profile",
+      "textClasses": "visuallyhidden",
       "path": "#",
       "alt": "Profile icon",
-      "imgs?": [
+      "imgs": [
         {
         "svg": "../../assets/img/patterns/molecules/nav-secondary-profile-ic.svg",
-          "classes?": "nav-secondary__profile-icon",
+          "classes": "nav-secondary__profile-icon",
           "hires": {
           "path": "../../assets/img/patterns/molecules/nav-secondary-profile-ic_2x.png",
             "width": "28w"


### PR DESCRIPTION
At the request of @thewilkybarkid this update makes template field names useable within legal PHP variable names by removing the '?' where it was used for some of them, and also imposes a camelCase naming convention.

Please follow this naming convention from now on [looks in mirror].
