### PR TITLE
Updates to View Selector pattern:

### DIFF
--- a/assets/img/icons/article-hover.svg
+++ b/assets/img/icons/article-hover.svg
@@ -1,6 +1,12 @@
-<svg width="14" height="14" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg">
-  <title>
-    article-hover
-  </title>
-  <path d="M11.667 1H2.333C1.6 1 1 1.6 1 2.333v9.334C1 12.4 1.6 13 2.333 13h9.334C12.4 13 13 12.4 13 11.667V2.333C13 1.6 12.4 1 11.667 1zM11 5H3V3h8v2zm0 3H3V6h8v2zm-3 3H3V9h5v2z" fill="#0288D1" fill-rule="evenodd"/>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="12px" height="12px" viewBox="0 0 12 12" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 3.6.1 (26313) - http://www.bohemiancoding.com/sketch -->
+    <title>article-hover</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="article-hover" fill="#0288D1">
+            <path d="M10.667,0 L1.333,0 C0.6,0 0,0.6 0,1.333 L0,10.667 C0,11.4 0.6,12 1.333,12 L10.667,12 C11.4,12 12,11.4 12,10.667 L12,1.333 C12,0.6 11.4,0 10.667,0 L10.667,0 Z M10,4 L2,4 L2,2 L10,2 L10,4 L10,4 Z M10,7 L2,7 L2,5 L10,5 L10,7 L10,7 Z M7,10 L2,10 L2,8 L7,8 L7,10 L7,10 Z" id="Shape"></path>
+        </g>
+    </g>
 </svg>

--- a/assets/img/icons/article-reverse.svg
+++ b/assets/img/icons/article-reverse.svg
@@ -1,6 +1,12 @@
-<svg width="14" height="14" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg">
-  <title>
-    article-reverse
-  </title>
-  <path d="M11.667 1H2.333C1.6 1 1 1.6 1 2.333v9.334C1 12.4 1.6 13 2.333 13h9.334C12.4 13 13 12.4 13 11.667V2.333C13 1.6 12.4 1 11.667 1zM11 5H3V3h8v2zm0 3H3V6h8v2zm-3 3H3V9h5v2z" fill="#FFF" fill-rule="evenodd"/>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="12px" height="12px" viewBox="0 0 12 12" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 3.6.1 (26313) - http://www.bohemiancoding.com/sketch -->
+    <title>article-reverse</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="article-reverse" fill="#FFFFFF">
+            <path d="M10.667,0 L1.333,0 C0.6,0 0,0.6 0,1.333 L0,10.667 C0,11.4 0.6,12 1.333,12 L10.667,12 C11.4,12 12,11.4 12,10.667 L12,1.333 C12,0.6 11.4,0 10.667,0 L10.667,0 Z M10,4 L2,4 L2,2 L10,2 L10,4 L10,4 Z M10,7 L2,7 L2,5 L10,5 L10,7 L10,7 Z M7,10 L2,10 L2,8 L7,8 L7,10 L7,10 Z" id="Shape"></path>
+        </g>
+    </g>
 </svg>

--- a/assets/img/icons/article.svg
+++ b/assets/img/icons/article.svg
@@ -1,6 +1,12 @@
-<svg width="14" height="14" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg">
-  <title>
-    article copy
-  </title>
-  <path d="M11.667 1H2.333C1.6 1 1 1.6 1 2.333v9.334C1 12.4 1.6 13 2.333 13h9.334C12.4 13 13 12.4 13 11.667V2.333C13 1.6 12.4 1 11.667 1zM11 5H3V3h8v2zm0 3H3V6h8v2zm-3 3H3V9h5v2z" fill="#212121" fill-rule="evenodd"/>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="12px" height="12px" viewBox="0 0 12 12" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 3.6.1 (26313) - http://www.bohemiancoding.com/sketch -->
+    <title>article</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="article" fill="#212121">
+            <path d="M10.667,0 L1.333,0 C0.6,0 0,0.6 0,1.333 L0,10.667 C0,11.4 0.6,12 1.333,12 L10.667,12 C11.4,12 12,11.4 12,10.667 L12,1.333 C12,0.6 11.4,0 10.667,0 L10.667,0 Z M10,4 L2,4 L2,2 L10,2 L10,4 L10,4 Z M10,7 L2,7 L2,5 L10,5 L10,7 L10,7 Z M7,10 L2,10 L2,8 L7,8 L7,10 L7,10 Z" id="Shape"></path>
+        </g>
+    </g>
 </svg>

--- a/assets/sass/patterns/molecules/view-selector.scss
+++ b/assets/sass/patterns/molecules/view-selector.scss
@@ -9,15 +9,28 @@
   font-family: $font-secondary;
   line-height: 1.1;
   margin: 0;
-  @include padding(0 0 10 0);
+  @include margin(0 0 13 0);
 }
 
 .view-selector__link {
   color: $color-text;
-  @include font-size(14);
+  display: block;
+  @include font-size(11);
   font-weight: 700;
   text-decoration: none;
-  @include padding(20, "left");
+
+  .icon {
+    display: inline-block;
+    @include height(14);
+    @include margin(5, "right");
+    @include width(15);
+    vertical-align: middle;
+  }
+
+  span {
+    display: inline-block;
+    vertical-align: middle;
+  }
 
   &:hover {
     color: $color-primary;
@@ -25,32 +38,38 @@
 }
 
 .view-selector__link--article {
-  background: url("../img/icons/article.png") 1px 49% no-repeat;
-  background: url("../img/icons/article.svg") 0 49% no-repeat, linear-gradient(transparent, transparent);
+  .icon {
+    background: url("../img/icons/article.png") 1px 50% no-repeat;
+    background: url("../img/icons/article.svg") 1px 50% no-repeat, linear-gradient(transparent, transparent);
+  }
 
-  &:hover {
-    background: url("../img/icons/article-hover.png") 1px 49% no-repeat;
-    background: url("../img/icons/article-hover.svg") 0 49% no-repeat, linear-gradient(transparent, transparent);
+  &:hover .icon {
+    background: url("../img/icons/article-hover.png") 1px 50% no-repeat;
+    background: url("../img/icons/article-hover.svg") 1px 50% no-repeat, linear-gradient(transparent, transparent);
   }
 }
 
 .view-selector__link--figures {
-  background: url("../img/icons/figures.png") 1px 49% no-repeat;
-  background: url("../img/icons/figures.svg") 1px 49% no-repeat, linear-gradient(transparent, transparent);
+  .icon {
+    background: url("../img/icons/figures.png") 1px 50% no-repeat;
+    background: url("../img/icons/figures.svg") 1px 50% no-repeat, linear-gradient(transparent, transparent);
+  }
 
-  &:hover {
-    background: url("../img/icons/figures-hover.png") 1px 49% no-repeat;
-    background: url("../img/icons/figures-hover.svg") 1px 49% no-repeat, linear-gradient(transparent, transparent);
+  &:hover .icon {
+    background: url("../img/icons/figures-hover.png") 1px 50% no-repeat;
+    background: url("../img/icons/figures-hover.svg") 1px 50% no-repeat, linear-gradient(transparent, transparent);
   }
 }
 
 .view-selector__link--sidebyside {
-  background: url("../img/icons/sidebyside.png") 0 49% no-repeat;
-  background: url("../img/icons/sidebyside.svg") 0 49% no-repeat, linear-gradient(transparent, transparent);
+  .icon {
+    background: url("../img/icons/sidebyside.png") 0 50% no-repeat;
+    background: url("../img/icons/sidebyside.svg") 0 50% no-repeat, linear-gradient(transparent, transparent);
+  }
 
-  &:hover {
-    background: url("../img/icons/sidebyside-hover.png") 0 49% no-repeat;
-    background: url("../img/icons/sidebyside-hover.svg") 0 49% no-repeat, linear-gradient(transparent, transparent);
+  &:hover .icon {
+    background: url("../img/icons/sidebyside-hover.png") 0 50% no-repeat;
+    background: url("../img/icons/sidebyside-hover.svg") 0 50% no-repeat, linear-gradient(transparent, transparent);
   }
 }
 
@@ -61,7 +80,7 @@
   display: block;
   @include font-size(14);
   font-weight: 700;
-  @include margin(10, "bottom");
+  @include margin(13, "bottom");
   @include padding(20, "left");
 }
 
@@ -75,7 +94,7 @@
   font-family: $font-secondary;
   line-height: 1.1;
   margin: 0;
-  @include padding(0 0 10 0);
+  @include padding(0 0 13 0);
 }
 
 .view-selector__jump_link {
@@ -93,43 +112,49 @@
   .view-selector__list {
     display: flex;
     margin: auto;
-    max-width: #{get-rem-from-px(340)}rem;
+    max-width: #{get-rem-from-px(250)}rem;
+  }
+
+  .view-selector__list-item {
+    margin: 0;
   }
 
   /** Selector nesting here because otherwise this all gets horrible quickly **/
   .view-selector__list-item--article {
-    border: 1px solid $color-text-dividers;
-    border-radius: 5px 0 0 5px;
+    border-bottom: 1px solid $color-text-dividers;
+    border-left: 1px solid $color-text-dividers;
+    border-top: 1px solid $color-text-dividers;
+    border-radius: 4px 0 0 4px;
     flex: 1 50%;
-    @include padding(8 4);
     text-align: center;
 
     &.view-selector__list-item--active {
-      .view-selector__link {
-        background: url("../img/icons/article-reverse.png") 0 49% no-repeat;
-        background: url("../img/icons/article-reverse.svg") 0 49% no-repeat, linear-gradient(transparent, transparent);
+      .view-selector__link .icon {
+        background: url("../img/icons/article-reverse.png") 0 50% no-repeat;
+        background: url("../img/icons/article-reverse.svg") 0 50% no-repeat, linear-gradient(transparent, transparent);
       }
     }
   }
 
   .view-selector__list-item--figures {
-    border: 1px solid $color-text-dividers;
-    border-radius: 0 5px 5px 0;
+    border-bottom: 1px solid $color-text-dividers;
+    border-right: 1px solid $color-text-dividers;
+    border-top: 1px solid $color-text-dividers;
+    border-radius: 0 4px 4px 0;
     flex: 1 50%;
-    @include padding(8 4);
     text-align: center;
 
     &.view-selector__list-item--active {
-      .view-selector__link {
-        background: url("../img/icons/figures-reverse.png") 0 49% no-repeat;
-        background: url("../img/icons/figures-reverse.svg") 0 49% no-repeat, linear-gradient(transparent, transparent);
+      .view-selector__link .icon {
+        background: url("../img/icons/figures-reverse.png") 0 50% no-repeat;
+        background: url("../img/icons/figures-reverse.svg") 0 50% no-repeat, linear-gradient(transparent, transparent);
       }
     }
   }
 
   .view-selector__list-item--active {
     background-color: $color-primary;
-    border: 2px solid $color-primary;
+    border: 1px solid $color-primary;
 
     .view-selector__link {
       color: $color-text--reverse;
@@ -142,5 +167,11 @@
 
   .view-selector__list-item--jump {
     display: none;
+  }
+
+  .view-selector__link {
+    @include padding(8 4);
+    text-align: center;
+    text-transform: uppercase;
   }
 }

--- a/source/_patterns/01-molecules/navigation/view-selector.mustache
+++ b/source/_patterns/01-molecules/navigation/view-selector.mustache
@@ -2,13 +2,13 @@
 <div class="view-selector">
   <ul class="view-selector__list">
     <li class="view-selector__list-item view-selector__list-item--article view-selector__list-item--active">
-      <a href="#" class="view-selector__link view-selector__link--article">Article</a>
+      <a href="#" class="view-selector__link view-selector__link--article"><i class="icon"></i><span>Article</span></a>
     </li>
     <li class="view-selector__list-item view-selector__list-item--figures">
-      <a href="#" class="view-selector__link view-selector__link--figures">Figures</a>
+      <a href="#" class="view-selector__link view-selector__link--figures"><i class="icon"></i><span>Figures</span></a>
     </li>
     <li class="view-selector__list-item view-selector__list-item--sidebyside">
-      <a href="#" class="view-selector__link view-selector__link--sidebyside">Side by side</a>
+      <a href="#" class="view-selector__link view-selector__link--sidebyside"><i class="icon"></i><span>Side by side</span></a>
     </li>
     <li class="view-selector__list-item view-selector__list-item--jump">
 


### PR DESCRIPTION
- Article icon svg updated to remove the 1px by 1px coord shift.
- The 'buttons' in small screen, due to using padding on the list-item, were previously limited to just the text. I have now reversed the paddings so that the whole area is the link, and therefore, widened the hotbox to the whole 'button'.
- Controversially, I have moved the icons into an `<i>` element with `.icon` class. I have also wrapped the text inside a span. This allows the link to be a `display: block`, but keeps the text and icon centered. It's the only way. The icon class/pattern may become global later. Still deciding.
