### PR TITLE
Add IE fix from browser testing

### DIFF
--- a/assets/js/components/ArticleDownloadLinksList.js
+++ b/assets/js/components/ArticleDownloadLinksList.js
@@ -13,7 +13,10 @@ module.exports = class ArticleDownloadLinksList {
     this.window = _window;
     this.doc = doc;
     this.$elm = $elm;
-    this.$elm.classList.add('article-download-links-list--js', 'visuallyhidden');
+
+    // One statement per class name because IE doesn't support multiple strings, comma separated.
+    this.$elm.classList.add('article-download-links-list--js');
+    this.$elm.classList.add('visuallyhidden');
     this.moveList();
     this.$toggler = this.doc.querySelector('.content-header__download_link');
     this.$toggler.addEventListener('click', this.toggle.bind(this));

--- a/source/_patterns/01-molecules/components/article-download-links-list.mustache
+++ b/source/_patterns/01-molecules/components/article-download-links-list.mustache
@@ -1,5 +1,5 @@
 <div data-behaviour="ArticleDownloadLinksList" id="articleDownloadLinksList" aria-labelledby="articleDownloadLinksListLabel">
-  <div class="visuallyhidden"><span id="articleDownloadLinksListLabel">A three part list of links to download the article, or parts of the article, in various formats.</span> <a href="">Skip this list</a></div>
+  <div class="visuallyhidden"><span id="articleDownloadLinksListLabel">A three part list of links to download the article, or parts of the article, in various formats.</span><!-- Consider skip link here for AT --></div>
   <h3 class="article-download-links-list__heading">Downloads<span class="visuallyhidden"> (links to download the article or parts of the article as PDF)</span></h3>
   <ul class="article-download-list">
     <li><a href="{{dlLinkArticle}}" class="article-download-links-list__link">Article</a></li>


### PR DESCRIPTION
Works around the IE bug where `classList.add()` only honours the first string provided.

Replaces broken "skip" link with a comment to consider implementing one as part of wider accessibility review.
