### PR TITLE
Fully implement typographical style mixins where appropriate

### DIFF
--- a/assets/fonts/fonts.css
+++ b/assets/fonts/fonts.css
@@ -13,6 +13,13 @@
     url("f26faddb-86cc-4477-a253-1e1287684336.woff") format("woff");
   font-weight: 600;
 }
+/* Medium */
+@font-face {
+  font-family: "Avenir Next Webfont";
+  src: url("627fbb5a-3bae-4cd9-b617-2f923e29d55e.woff2") format("woff2"),
+  url("f26faddb-86cc-4477-a253-1e1287684336.woff") format("woff");
+}
+
 /* Regular */
 @font-face {
   font-family: "PT Serif Webfont";

--- a/assets/sass/_typographic-hierarchy.scss
+++ b/assets/sass/_typographic-hierarchy.scss
@@ -136,6 +136,7 @@
   font-family: $font-primary;
   @include font-size(14);
   font-style: italic;
+  font-weight: 400;
   line-height: 1.3;
 }
 
@@ -149,16 +150,25 @@
   // bold, not demibold
   font-family: $font-secondary;
   @include font-size(13);
-  font-weight: 700;
+  font-weight: bold;
   line-height: 1.3;
 }
 
-@mixin fig-caption-typeg() {
+@mixin fig-caption-heading-typeg() {
   font-family: $font-secondary;
   @include font-size(13);
   font-weight: 700;
   line-height: 1.3;
   @include padding(3, "bottom");
+}
+
+@mixin fig-caption-text-typeg($space-underneath: 19) {
+  font-family: $font-secondary;
+  @include font-size(13);
+  font-weight: 600;
+  line-height: 1.3;
+  @include padding($space-underneath, "bottom");
+  text-decoration: none;
 }
 
 @mixin table-head-typeg() {
@@ -172,6 +182,7 @@
 @mixin table-cell-typeg() {
   font-family: $font-secondary;
   @include font-size(13);
+  font-weight: 600;
   line-height: 1.3;
   @include padding(19, "bottom");
 }
@@ -228,6 +239,13 @@
   }
 }
 
+@mixin typeg-portal-quick-nav() {
+  font-family: $font-secondary;
+  @include font-size(12);
+  font-weight: 700;
+  line-height: 1.85;
+}
+
 @mixin msa-link($is-wide: false) {
   font-family: $font-secondary;
   @include font-size(12);
@@ -253,6 +271,28 @@
 @mixin label-subject-typeg() {
   @include _label-typeg();
   color: $color-primary;
+}
+
+// FORMS
+
+@mixin typeg-form-label {
+  color: $color-text;
+  font-family: $font-secondary;
+  @include font-size(14);
+  font-weight: 700;
+  line-height: 1.3;
+  @include margin(6, "bottom");
+}
+
+// No definition in developer docs, this is inferred from styles already applied to filter-group.
+//Update as necessary.
+@mixin typeg-checkboxes() {
+  color: $color-text;
+  font-family: $font-secondary;
+  @include font-size(14);
+  font-weight: 700;
+  line-height: 1.3;
+  @include padding(1, "bottom");
 }
 
 // FOR ITEMS IN LISTS

--- a/assets/sass/patterns/atoms/doi.scss
+++ b/assets/sass/patterns/atoms/doi.scss
@@ -1,15 +1,12 @@
 
 .doi {
-  color: $color-text-secondary;
-  font-family: $font-secondary;
-  @include font-size(11);
-  font-weight: 700;
-  line-height: 1;
+  @include label-content-typeg($color-text-secondary);
 }
 
 .doi__link {
   color: $color-text-secondary;
   text-decoration: none;
+  text-transform: none;
 
   &:hover {
     color: $color-primary;

--- a/assets/sass/patterns/atoms/form-label.scss
+++ b/assets/sass/patterns/atoms/form-label.scss
@@ -1,10 +1,4 @@
 
 .form-label {
-  color: $color-text;
   display: block;
-  font-family: $font-secondary;
-  @include font-size(14);
-  font-weight: bold;
-  line-height: 1.3;
-  @include margin(6, "bottom");
 }

--- a/assets/sass/patterns/atoms/message-bar.scss
+++ b/assets/sass/patterns/atoms/message-bar.scss
@@ -2,10 +2,6 @@
 .message-bar {
   background-color: $color-text-ui-background-hue;
   border-radius: 4px;
-  color: $color-text-secondary;
-  font-family: $font-secondary;
-  @include font-size(11);
-  font-weight: 700;
+  @include label-content-typeg($color-text-secondary);
   @include padding(8 7);
-  text-transform: uppercase;
 }

--- a/assets/sass/patterns/molecules/article-meta.scss
+++ b/assets/sass/patterns/molecules/article-meta.scss
@@ -13,11 +13,9 @@
 }
 
 .article-meta__group_title {
-  color: $color-text-secondary;
-  @include font-size(11);
-  font-weight: 600;
+  @include label-content-typeg($color-text-secondary);
+  //font-weight: 600;
   @include margin(0 0 2 0);
-  text-transform: uppercase;
 }
 
 .article-meta__link_list {
@@ -28,13 +26,9 @@
 
 .article-meta__link_list_item {
   display: inline;
-  font-family: $font-secondary;
-  @include font-size(11);
-  font-weight: 600;
-  line-height: 1.8;
+  @include label-subject-typeg();
   margin: 0;
   padding: 0;
-  text-transform: uppercase;
 }
 
 .article-meta__link {

--- a/assets/sass/patterns/molecules/audio-player.scss
+++ b/assets/sass/patterns/molecules/audio-player.scss
@@ -26,7 +26,7 @@
 
 .audio-player__header {
   color: $color-text--reverse;
-  font-family: $font-primary;
+  @include listing-side-art-title-typeg();
   @include margin(5, "bottom");
 }
 
@@ -51,7 +51,7 @@
 }
 
 .audio-player__progress_bar {
-  background-color: #666;
+  background-color: $color-text-secondary;
   height: 6px;
   left: 0;
   position: absolute;
@@ -60,10 +60,8 @@
 }
 
 .audio-player__times {
-  color: #666;
   float: right;
-  font-family: $font-secondary;
-  @include font-size(12);
+  @include label-content-typeg($color-text-secondary);
 }
 
 .audio-player__current_time:after {

--- a/assets/sass/patterns/molecules/captioned-image.scss
+++ b/assets/sass/patterns/molecules/captioned-image.scss
@@ -18,18 +18,11 @@
 }
 
 .captioned-image__caption_heading {
-  font-family: $font-secondary;
-  @include font-size(13);
-  font-weight: 700;
-  margin: 0;
-  padding-bottom: 0;
+  @include fig-caption-heading-typeg();
 }
 
 .captioned-image__caption_text {
-  font-family: $font-secondary;
-  @include font-size(13);
-  margin: 0;
-  @include padding(0 0 5 0);
+  @include fig-caption-text-typeg();
 }
 
 @media only screen and (min-width: #{get-rem-from-px(430)}em) {

--- a/assets/sass/patterns/molecules/contextual-data.scss
+++ b/assets/sass/patterns/molecules/contextual-data.scss
@@ -1,11 +1,7 @@
 
 .contextual-data {
   border-bottom: 1px solid $color-text-dividers;
-  color: $color-text-secondary;
-  font-family: $font-secondary;
-  @include font-size(11);
-  font-weight: 700;
-  line-height: 1;
+  @include label-content-typeg($color-text-secondary);
   @include padding(15 , "top");
 }
 
@@ -18,19 +14,14 @@
 
 .contextual-data__list_title {
   display: inline-block;
-  font-family: $font-secondary;
-  @include font-size(11);
-  line-height: 1;
+  @include label-content-typeg($color-text-secondary);
   margin: 0;
   padding: 0;
-  text-transform: uppercase;
 }
 
 .contextual-data__list_desc {
   display: inline-block;
-  font-family: $font-secondary;
-  @include font-size(11);
-  line-height: 1;
+  @include label-content-typeg($color-text-secondary);
   margin: 0;
   @include padding(0 5 0 0);
 }

--- a/assets/sass/patterns/molecules/filter-group.scss
+++ b/assets/sass/patterns/molecules/filter-group.scss
@@ -1,6 +1,6 @@
 
 .filter-group__title {
-  @include font-size(16);
+  @include listing-main-subtitle-typeg();
   @include margin(0 0 8 0);
 }
 
@@ -15,12 +15,7 @@
 }
 
 .filter-group__item_label {
-  color: $color-text;
-  font-family: $font-secondary;
-  @include font-size(14);
-  font-weight: 700;
-  line-height: 1.3;
-  @include padding(1, "bottom");
+  @include typeg-checkboxes();
 }
 
 .filter-group__results {

--- a/assets/sass/patterns/molecules/pull-quote.scss
+++ b/assets/sass/patterns/molecules/pull-quote.scss
@@ -2,20 +2,18 @@
 .pull-quote {
   background: url("../img/icons/quote-start.png") 0 0 no-repeat;
   background: url("../img/icons/quote-start.svg") 0 0 no-repeat, linear-gradient(transparent, transparent);
-  font-family: $font-secondary;
-  @include font-size(24);
-  font-weight: 700;
-  line-height: 1.3;
   @include margin(0 48 0 0);
   @include padding(43 5 0 5);
 
   p {
-    font-family: $font-secondary;
-    @include font-size(24);
-    font-weight: 700;
-    line-height: 1.3;
+    @include pullquote-typeg();
     margin: 0;
     padding: 0;
+
+    @media only all and (min-width: #{$bkpt-content-header}px) {
+      @include pullquote-typeg(true);
+    }
+
   }
 
   p + p {
@@ -29,7 +27,6 @@
     &:after {
       background: url("../img/icons/quote-end.png") 0 0 no-repeat;
       background: url("../img/icons/quote-end.svg") 0 0 no-repeat, linear-gradient(transparent, transparent);
-      // bottom: -#{get-rem-from-px(16)}rem;
       content: "";
       display: block;
       height: #{get-rem-from-px(33)}rem;
@@ -43,11 +40,7 @@
   cite {
     color: $color-text-placeholder;
     display: block;
-    font-family: $font-primary;
-    @include font-size(14);
-    font-style: italic;
-    font-weight: 400;
-    line-height: 1.3;
+    @include pullquote-attrib-typeg();
     @include padding(18, "top");
 
     a {

--- a/assets/sass/patterns/molecules/site-links-list.scss
+++ b/assets/sass/patterns/molecules/site-links-list.scss
@@ -11,10 +11,7 @@
 }
 
 .site-links-list__list_item {
-  font-family: $font-secondary;
-  @include font-size(12);
-  font-weight: 700;
-  line-height: 1.85;
+  @include typeg-portal-quick-nav();
   margin: 0;
   padding: 0;
 }
@@ -43,13 +40,13 @@
   }
 
   .site-links-list__list:nth-child(1) {
-    padding-right: #{get-rem-from-px(8)}rem;
+    @include padding(8, "right");
   }
   .site-links-list__list:nth-child(2) {
-    padding-left: #{get-rem-from-px(8)}rem;
-    padding-right: #{get-rem-from-px(8)}rem;
+    @include padding(8, "left");
+    @include padding(8, "right");
   }
   .site-links-list__list:nth-child(3) {
-    padding-left: #{get-rem-from-px(8)}rem;
+    @include padding(8, "left");
   }
 }

--- a/assets/sass/patterns/molecules/viewer-inline.scss
+++ b/assets/sass/patterns/molecules/viewer-inline.scss
@@ -13,9 +13,12 @@
   align-self: center;
   display: inline-block;
   flex: 1 auto;
-  font-family: $font-secondary;
-  @include font-size(13);
-  line-height: 1.3;
+  @include fig-caption-text-typeg(0);
+  @include nospace("bottom");
+}
+
+.viewer-inline__header_text__prominant {
+  @include fig-heading-typeg();
 }
 
 .viewer-inline__header_link {
@@ -75,9 +78,7 @@
 .viewer-inline__footer_link {
   color: $color-text;
   display: inline-block;
-  font-family: $font-secondary;
-  @include font-size(13);
-  text-decoration: none;
+  @include fig-caption-text-typeg(0);
 
   &:hover {
     color: $color-primary;

--- a/assets/sass/patterns/organisms/_content-header-nonarticle.scss
+++ b/assets/sass/patterns/organisms/_content-header-nonarticle.scss
@@ -6,8 +6,7 @@
   position: relative;
 
   .content-header__download_link {
-    margin-top: 5px;
-    margin-top: #{get-rem-from-px(5)}rem;
+    @include margin(5, "top");
     position: absolute;
     right: 0;
   }

--- a/assets/sass/patterns/organisms/email-cta.scss
+++ b/assets/sass/patterns/organisms/email-cta.scss
@@ -10,6 +10,7 @@
 }
 
 .email-cta__header_text {
+  @include h2-typeg();
   color: $color-text;
   margin: 0;
   @include padding(0 0 7 0);
@@ -17,9 +18,6 @@
 
 .email-cta__sub_header {
   color: $color-text;
-  font-family: $font-primary;
-  @include font-size(16);
-  font-weight: 500;
+  @include body-typeg();
   margin: 0;
-  @include padding(0 0 24 0);
 }

--- a/source/_patterns/01-molecules/components/viewer-inline.mustache
+++ b/source/_patterns/01-molecules/components/viewer-inline.mustache
@@ -5,7 +5,7 @@
     <!-- For the JS -->
     <div class="viewer-inline__viewer_controls"></div>
 
-    <div class="viewer-inline__header_text"><strong>Fig 444</strong> with 888 supplements. <a href="#" class="viewer-inline__header_link">see all</a></div>
+    <div class="viewer-inline__header_text"><span class="viewer-inline__header_text__prominant">Fig 444</span> with 888 supplements. <a href="#" class="viewer-inline__header_link">see all</a></div>
 
     <div class="viewer-inline__figure_access">
       <a href="#viewer-inline__footer" class="viewer-inline__figure_access_download"><span class="visuallyhidden">Download</span></a>

--- a/source/_patterns/02-organisms/global/email-cta.json
+++ b/source/_patterns/02-organisms/global/email-cta.json
@@ -1,0 +1,13 @@
+{
+  "emailCta": {
+    "formAction" : "#",
+    "formId": "myCompactForm",
+    "formMethod": "GET",
+    "label": "Email",
+    "inputType": "email",
+    "inputName": "email",
+    "inputValue": "",
+    "inputPlaceholder": "you@email.com",
+    "ctaText": "Go"
+  }
+}

--- a/source/_patterns/02-organisms/global/email-cta.mustache
+++ b/source/_patterns/02-organisms/global/email-cta.mustache
@@ -8,9 +8,9 @@
       </header>
 
       <h3 class="email-cta__sub_header">Sign up for alerts</h3>
-
-      {{> molecules-compact-form }}
-
+      {{#emailCta}}
+        {{> molecules-compact-form }}
+      {{/emailCta}}
   </div>
 
 </section>

--- a/source/_patterns/04-pages/article--research.json
+++ b/source/_patterns/04-pages/article--research.json
@@ -391,6 +391,18 @@
     }
   ],
 
+  "emailCta": {
+    "formAction" : "#",
+    "formId": "myCompactForm",
+    "formMethod": "GET",
+    "label": "Email",
+    "inputType": "email",
+    "inputName": "email",
+    "inputValue": "",
+    "inputPlaceholder": "you@email.com",
+    "ctaText": "Go"
+  },
+
   "footerMenuLinks1": [
     { "name": "About", "url": "#" },
     { "name": "Alerts", "url": "#" },

--- a/source/_patterns/04-pages/collection.json
+++ b/source/_patterns/04-pages/collection.json
@@ -909,6 +909,18 @@
     }
   ],
 
+  "emailCta": {
+    "formAction" : "#",
+    "formId": "myCompactForm",
+    "formMethod": "GET",
+    "label": "Email",
+    "inputType": "email",
+    "inputName": "email",
+    "inputValue": "",
+    "inputPlaceholder": "you@email.com",
+    "ctaText": "Go"
+  },
+
   "footerMenuLinks1": [
     { "name": "About", "url": "#" },
     { "name": "Alerts", "url": "#" },

--- a/source/_patterns/04-pages/msa.json
+++ b/source/_patterns/04-pages/msa.json
@@ -519,6 +519,18 @@
     }
   ],
 
+  "emailCta": {
+    "formAction" : "#",
+    "formId": "myCompactForm",
+    "formMethod": "GET",
+    "label": "Email",
+    "inputType": "email",
+    "inputName": "email",
+    "inputValue": "",
+    "inputPlaceholder": "you@email.com",
+    "ctaText": "Go"
+  },
+
   "footerMenuLinks1": [
     { "name": "About", "url": "#" },
     { "name": "Alerts", "url": "#" },

--- a/source/_patterns/04-pages/podcast.json
+++ b/source/_patterns/04-pages/podcast.json
@@ -376,6 +376,18 @@
     }
   ],
 
+  "emailCta": {
+    "formAction" : "#",
+    "formId": "myCompactForm",
+    "formMethod": "GET",
+    "label": "Email",
+    "inputType": "email",
+    "inputName": "email",
+    "inputValue": "",
+    "inputPlaceholder": "you@email.com",
+    "ctaText": "Go"
+  },
+
   "footerMenuLinks1": [
     { "name": "About", "url": "#" },
     { "name": "Alerts", "url": "#" },


### PR DESCRIPTION
Refactor message-bar atom to use typographic styles

Fix typography for article-meta

Fix typography and colours for audio-player

Update styles for captioned-image

Refactor contextual-data to use typographic styles

Refactor filter-group to use typographic styles

Refactor pullquote to use typographic styles

Refactor viewer-inline to use typographic styles

Refactor one instance of margin to use margin mixin (minor)

Refactor email-cta typographical styles & add missing data

Refactor form-label & site-links-list to use typographic styles & padding mixin
