### PR TITLE
Include partial's JavaScript

### DIFF
--- a/source/_patterns/01-molecules/components/search-box.yaml
+++ b/source/_patterns/01-molecules/components/search-box.yaml
@@ -2,7 +2,8 @@ assets:
   css:
     - search-box.css
     - $ref: compact-form.yaml#/assets/css
-  js: []
+  js:
+    - $ref: compact-form.yaml#/assets/js
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object


### PR DESCRIPTION
There's none at the moment, but might be in the future. This will also avoid copy–paste errors.
