### PR TITLE
Reset errors when validating

### DIFF
--- a/bin/validate
+++ b/bin/validate
@@ -32,6 +32,7 @@ foreach ($finder as $file) {
     }
 
     foreach ($jsonFinder as $json) {
+        $validator->reset();
         $validator->check(json_decode(file_get_contents($json)), $yaml->schema);
         if (!$validator->isValid()) {
             $exit = 1;


### PR DESCRIPTION
The second commit forces the `additionalProperties` setting to `false` for any objects when validating internally, so you're notified if there's any properties not mentioned in the schema (refs #195).
