### PR TITLE
Make main menu items required

### DIFF
--- a/source/_patterns/01-molecules/navigation/main-menu.yaml
+++ b/source/_patterns/01-molecules/navigation/main-menu.yaml
@@ -35,6 +35,7 @@ schema:
         required:
           - title
           - titleId
+          - items
       minItems: 1
   required:
     - mainMenuLinks


### PR DESCRIPTION
This needs confirming, but I assume that a main menu link group actually requires at least one link, rather than just a title.
