### PR TITLE
Ignore resource errors from mocha-phantom

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -246,7 +246,7 @@ gulp.task('browserify-tests', (done) => {
 
 gulp.task('test', ['browserify-tests', 'js'], () => {
   return gulp.src('./test/*.html')
-    .pipe(mochaPhantomjs({reporter: 'spec'}))
+    .pipe(mochaPhantomjs({reporter: 'spec', 'ignore-resource-errors': true}))
     .pipe(reload());
 });
 


### PR DESCRIPTION
This config change prevents the test run from failing when a resource load errors. Not always a good idea as can mask failed loading of required assets. It can be removed later, but for now it allows the Jenkins test run to pass when an external placeholder image load fails.
