### PR TITLE
Prevent #mainMenu fragment

### DIFF
--- a/assets/js/components/SiteHeader.js
+++ b/assets/js/components/SiteHeader.js
@@ -50,6 +50,7 @@ module.exports = class SiteHeader {
       this.window.addEventListener('click', this.checkForMenuClose.bind(this));
     }
 
+    e.preventDefault();
     e.stopPropagation();
   }
 


### PR DESCRIPTION
Currently clicking the main menu link in the header causes a `#mainMenu` fragment to be appended to the URL. This stops it.
