### PR TITLE
Add responsive iframe

### DIFF
--- a/assets/sass/patterns/atoms/iframe.scss
+++ b/assets/sass/patterns/atoms/iframe.scss
@@ -1,0 +1,18 @@
+@import "../../definitions";
+
+.iframe {
+  position: relative;
+  padding-bottom: 56.25%;
+  height: 0;
+  overflow: hidden;
+  max-width: 100%;
+
+  iframe {
+    border: 0;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
+}

--- a/source/_patterns/00-atoms/components/iframe.json
+++ b/source/_patterns/00-atoms/components/iframe.json
@@ -1,0 +1,4 @@
+{
+  "id": "id",
+  "src": "https://www.youtube.com/embed/6j0jRXPvpCE"
+}

--- a/source/_patterns/00-atoms/components/iframe.mustache
+++ b/source/_patterns/00-atoms/components/iframe.mustache
@@ -1,0 +1,3 @@
+<div class="iframe iframe--{{id}}">
+    <iframe src="{{src}}" {{#allowFullScreen}}allowfullscreen{{/allowFullScreen}}></iframe>
+</div>

--- a/source/_patterns/00-atoms/components/iframe.yaml
+++ b/source/_patterns/00-atoms/components/iframe.yaml
@@ -1,0 +1,20 @@
+assets:
+  css:
+    - iframe.css
+  js: []
+schema:
+  $schema: http://json-schema.org/draft-04/schema#
+  type: object
+  properties:
+    id:
+      type: string
+      minLength: 1
+    src:
+      type: string
+      minLength: 1
+    allowFullScreen:
+      type: boolean
+      default: false
+  required:
+    - id
+    - src

--- a/source/_patterns/04-pages/article--research.json
+++ b/source/_patterns/04-pages/article--research.json
@@ -355,6 +355,11 @@
     }
   ],
 
+  "iframe": {
+    "id": "id",
+    "src": "https://www.youtube.com/embed/6j0jRXPvpCE"
+  },
+
   "mainMenuLinks": [
     {
       "title": "Subjects",

--- a/source/_patterns/04-pages/article--research.mustache
+++ b/source/_patterns/04-pages/article--research.mustache
@@ -32,6 +32,10 @@
                 {{> molecules-article-section }}
               {{/articleSections}}
 
+              {{#iframe}}
+                {{> atoms-iframe }}
+              {{/iframe}}
+
               <!-- May need to make the article section pattern more content flexible (include other patterns/not have header). New variants? -->
               <section class="article-section">
 


### PR DESCRIPTION
We need to be able to embed YouTube videos etc. I've created a simple pattern for having a responsive `<iframe>`.

The `padding-bottom` should be overridden (hence the `id` property); it assumes a 16:9 ratio.

I've added an example to the article research page to show it in action.
