### PR TITLE
Add max-width to img

### DIFF
--- a/assets/sass/_normalize-overrides.scss
+++ b/assets/sass/_normalize-overrides.scss
@@ -134,3 +134,7 @@ small {
   display: block;
   clear: both;
 }
+
+img {
+  max-width: 100%;
+}


### PR DESCRIPTION
It's probably not a good idea to let images be bigger than their container by default. If for some reason it needs to happen, it should be explicit.
