### PR TITLE
Modify css build to accurately reflect what will happen upstream

### DIFF
--- a/assets/sass/build.scss
+++ b/assets/sass/build.scss
@@ -4,4 +4,4 @@
 
 @import "definitions";
 @import "reset";
-@import "patterns/**/*.scss";
+@import "patterns/**/[^_]*.scss";

--- a/assets/sass/patterns/organisms/_content-header-article.scss
+++ b/assets/sass/patterns/organisms/_content-header-article.scss
@@ -1,19 +1,12 @@
 @import "../../definitions";
+@import "content-header";
 
-// Includes some styles common to both research article and magazine article headers.
+// Includes styles common to both research article and magazine article headers.
 
 .content-header-article {
 
   &.content-header {
     @include padding(14, "top");
-  }
-
-  .meta:after {
-    border-bottom: 1px solid $color-text-dividers;
-    content: "";
-    display: block;
-    @include padding(12, "top");
-
   }
 
 }

--- a/assets/sass/patterns/organisms/content-header-article-magazine.scss
+++ b/assets/sass/patterns/organisms/content-header-article-magazine.scss
@@ -1,10 +1,21 @@
 @import "../../definitions";
+@import "content-header-article";
 
 // Contains styles unique to research article header & variants.
 
 .content-header-article-magazine {
 
-  .content-header__title {
+  &.content-header-article-magazine--background {
+
+    @include article-with-background;
+    background-repeat: no-repeat;
+    background-size: cover;
+
+    .date {
+      color: $color-text--reverse;
+    }
+  }
+    .content-header__title {
     @include margin(13, "bottom");
     @include margin(28, "top");
     padding-bottom: 0;
@@ -29,18 +40,6 @@
     .content-header__strapline {
       @include impact-statement-typeg("wide");
     }
-  }
-
-}
-
-.content-header-article-magazine--background {
-
-  @include article-with-background;
-  background-repeat: no-repeat;
-  background-size: cover;
-
-  .date {
-    color: $color-text--reverse;
   }
 
 }

--- a/assets/sass/patterns/organisms/content-header-article-research.scss
+++ b/assets/sass/patterns/organisms/content-header-article-research.scss
@@ -1,4 +1,5 @@
 @import "../../definitions";
+@import "content-header-article";
 
 // Contains research article-specific overrides.
 
@@ -6,6 +7,14 @@
 
   .meta {
     @include margin(30, "top");
+  }
+
+  .meta:after {
+    border-bottom: 1px solid $color-text-dividers;
+    content: "";
+    display: block;
+    @include padding(12, "top");
+
   }
 
 }

--- a/assets/sass/patterns/organisms/content-header-nonarticle.scss
+++ b/assets/sass/patterns/organisms/content-header-nonarticle.scss
@@ -1,4 +1,5 @@
 @import "../../definitions";
+@import "content-header";
 
 .content-header-nonarticle {
 


### PR DESCRIPTION
Ensure that the sass bundling used to generate css for PatternLab reflects what css will be available to content headers when individual css files are used.
