### PR TITLE
Create new 'listing' organism pattern

### DIFF
--- a/assets/sass/layout/_layout.scss
+++ b/assets/sass/layout/_layout.scss
@@ -8,6 +8,7 @@
  *
  * .listing-list is a list of items. It is the major content within a listing column. A listing column may contain one
  *    or more listing lists. Every listing-list in each listing column has a bottom margin expect the last one.
+ * NOTE: styles for .listing-list and .listing-list-item now live in listing.scss
  *
  * .listing-column-main contains the primary content lists. On a linearised layout it is the is the top-most content listing
  *    area. On a wider layout it is the main column containing listing content occupying at least the left and central
@@ -37,21 +38,6 @@
   @include margin(15, "top");
 }
 
-.listing-list {
-  @include nospace("left");
-  list-style-type: none;
-  padding-bottom: 0;
-  @include margin($listing-list-spacing, "bottom");
-}
-
-.listing-column-main ol.listing-list:last-of-type {
-  @include nospace("bottom");
-}
-
-.listing-column-secondary ol.listing-list:last-of-type {
-  @include nospace("bottom");
-}
-
 @media only all and (min-width: 800px) {
 
   .listing-column-main {
@@ -64,26 +50,3 @@
   }
 
 }
-
-.listing-list__item {
-  line-height: 1;
-}
-
-// Sets up the column layout at medium width for the secondary content lists.
-@media only all and (min-width: 550px) and (max-width: 799px) {
-
-  .listing-column-secondary .listing-list {
-    column-count: 2;
-    column-gap: #{get-rem-from-px(26)}rem;
-  }
-
-  .listing-column-secondary .listing-list__item {
-    break-inside: avoid;
-  }
-
-  .listing-column-secondary .see-more-link {
-    column-span: all;
-  }
-
-}
-

--- a/assets/sass/patterns/organisms/listing.scss
+++ b/assets/sass/patterns/organisms/listing.scss
@@ -1,0 +1,41 @@
+@import "../../definitions";
+
+/* .listing-list is a list of items. It is the major content within a listing column. A listing column may contain one
+ *    or more listing lists. Every listing-list in each listing column has a bottom margin expect the last one.
+ */
+.listing-list {
+  @include nospace("left");
+  list-style-type: none;
+  padding-bottom: 0;
+  @include margin($listing-list-spacing, "bottom");
+}
+
+.listing-column-main ol.listing-list:last-of-type {
+  @include nospace("bottom");
+}
+
+.listing-column-secondary ol.listing-list:last-of-type {
+  @include nospace("bottom");
+}
+
+.listing-list__item {
+  line-height: 1;
+}
+
+// Sets up the column layout at medium width for the secondary content lists.
+@media only all and (min-width: 550px) and (max-width: 799px) {
+
+  .listing-column-secondary .listing-list {
+    column-count: 2;
+    column-gap: #{get-rem-from-px(26)}rem;
+  }
+
+  .listing-column-secondary .listing-list__item {
+    break-inside: avoid;
+  }
+
+  .listing-column-secondary .see-more-link {
+    column-span: all;
+  }
+
+}

--- a/source/_patterns/00-atoms/components/see-more-link.mustache
+++ b/source/_patterns/00-atoms/components/see-more-link.mustache
@@ -1,1 +1,1 @@
-<a href="{{url}}" class="see-more-link">See more {{{name}}}</a>
+<a href="{{url}}" class="see-more-link">{{{name}}}</a>

--- a/source/_patterns/02-organisms/components/listing.mustache
+++ b/source/_patterns/02-organisms/components/listing.mustache
@@ -1,0 +1,30 @@
+{{> atoms-list-heading}}
+<ol class="listing-list">
+{{! isTeaserType and isProfileSnippetType are mutually exclusive. }}
+{{#isTeaserType}}
+  {{#items}}
+      <li class="listing-list__item">
+        {{> molecules-teaser }}
+    </li>
+  {{/items}}
+{{/isTeaserType}}
+
+{{#isProfileSnippetType}}
+  {{#items}}
+      <li class="listing-list__item">
+        {{> molecules-profile-snippet }}
+      </li>
+  {{/items}}
+{{/isProfileSnippetType}}
+
+{{#seeMoreLink}}
+  <li class="listing-list__item">
+    {{> atoms-see-more-link}}
+  </li>
+{{/seeMoreLink}}
+
+</ol>
+
+{{#loadMore}}
+  {{> molecules-load-more}}
+{{/loadMore}}

--- a/source/_patterns/02-organisms/components/listing.yaml
+++ b/source/_patterns/02-organisms/components/listing.yaml
@@ -1,0 +1,53 @@
+assets:
+  css:
+    - listing.css
+    - $ref: ../../01-molecules/teasers/teaser.yaml#/assets/css
+    - $ref: ../../01-molecules/components/profile-snippet.yaml#/assets/css
+    - $ref: ../../00-atoms/components/see-more-link.yaml#/assets/css
+    - $ref: ../../01-molecules/components/load-more.yaml#/assets/css
+  js: []
+schema:
+  $schema: http://json-schema.org/draft-04/schema#
+  type: object
+  allOf:
+    - properties:
+        heading:
+          type: string
+    - oneOf:
+        - properties:
+            isTeaserType:
+              type: boolean
+              enum:
+                - true
+            items:
+              type: array
+              minItems: 1
+              items:
+                $ref: ../../01-molecules/teasers/teaser.yaml#/schema
+          required:
+            - isTeaserType
+            - items
+        - properties:
+            isProfileSnippetType:
+              type: boolean
+              enum:
+                - true
+            items:
+              type: array
+              minItems: 1
+              items:
+                $ref: ../../01-molecules/components/profile-snippet.yaml#/schema
+          required:
+            - isProfileSnippetType
+            - items
+    - oneOf:
+        - properties:
+            seeMoreLink:
+              $ref: ../../00-atoms/components/see-more-link.yaml#/schema
+          required:
+            - seeMoreLink
+        - properties:
+            loadMore:
+              $ref: ../../01-molecules/components/load-more.yaml#/schema
+          required:
+            - loadMore

--- a/source/_patterns/02-organisms/components/listing~profile-snippet.json
+++ b/source/_patterns/02-organisms/components/listing~profile-snippet.json
@@ -1,0 +1,49 @@
+{
+  "heading": "Listing of profile snippets",
+  "isProfileSnippetType": true,
+  "items": [
+    {
+      "name": "Prabhat Jha",
+      "title": "University of Toronto",
+      "picture": {
+        "sources": [
+          {
+            "srcset": "http://lorempixel.com/180/180/people/1 180w",
+            "type": "image/png"
+          }
+        ],
+        "pictureClasses": "profile-snippet__picture",
+        "fallback": {
+          "srcset": "http://lorempixel.com/180/180/people/5 180w, http://lorempixel.com/90/90/people/1 90w",
+          "defaultPath": "http://lorempixel.com/90/90/people/1",
+          "altText": "Meaningful alt text here please.",
+          "classes": "profile-snippet__image"
+        }
+      }
+    },
+    {
+      "name": "Richard Losick",
+      "title": "Harvard University",
+      "picture": {
+        "sources": [
+          {
+            "srcset": "http://lorempixel.com/180/180/people/5 180w",
+            "type": "image/png"
+          }
+        ],
+        "pictureClasses": "profile-snippet__picture",
+        "fallback": {
+          "srcset": "http://lorempixel.com/180/180/people/5 180w, http://lorempixel.com/90/90/people/2 90w",
+          "defaultPath": "http://lorempixel.com/90/90/people/5",
+          "altText": "Meaningful alt text here please.",
+          "classes": "profile-snippet__image"
+        }
+      }
+    }
+  ],
+  "seeMoreLink": {
+    "name": "See more things!",
+    "url": "#"
+  }
+
+}

--- a/source/_patterns/02-organisms/components/listing~teasers.json
+++ b/source/_patterns/02-organisms/components/listing~teasers.json
@@ -1,0 +1,161 @@
+{
+  "heading": "Listing of teasers",
+  "isTeaserType": true,
+  "items": [
+    {
+      "contextLabel": {
+        "list": [
+          {
+            "name": "Microbiology and Infectious Disease",
+            "url": "#"
+          }
+        ]
+      },
+      "title": "Quorum sensing control of Type VI secretion factors restricts the proliferation of quorum-sensing mutants",
+      "url": "#",
+      "secondaryInfo": "Charlotte Majerczyk et al.",
+      "content": "Quorum-sensing control of <i>Burkholderia thailandensis</i> toxin and immunity pairs serves to police quorum-sensing mutants and may represent a general strategy whereby cooperators can police mutants.",
+      "footer": {
+        "meta": {
+          "text": "Research article",
+          "url": "#",
+          "date": {
+            "forHuman": {
+              "dayOfMonth": 16,
+              "month": "May",
+              "year": 2016
+            },
+            "forMachine": "2016-05-16"
+          }
+        },
+        "publishState": {
+          "vor": true
+        }
+      },
+
+      "image": {
+        "defaultPath": "http://unsplash.it/250/140/",
+        "srcset": "http://unsplash.it/500/280/ 500w, http://unsplash.it/250/140/ 250w",
+        "altText": "Meaningful alt text please.",
+        "classes": "teaser__img--big"
+      }
+    },
+
+    {
+      "subjects": {
+        "list": [
+          {
+            "name": "Epidemiology and Global Health",
+            "url": "#"
+          },
+          {
+            "name": "Microbiology and Infectious Disease",
+            "url": "#"
+          }
+        ]
+      },
+      "title": "Mapping global environmental suitability for Zika virus",
+      "url": "#",
+      "secondaryInfo": "Jane P Messina et al",
+      "footer": {
+        "meta": {
+          "text": "Research article",
+          "url": "#",
+          "date": {
+            "forHuman": {
+              "dayOfMonth": 19,
+              "month": "Apr",
+              "year": 2016
+            },
+            "forMachine": "2016-04-19"
+          }
+        },
+        "publishState": {
+          "vor": false
+        }
+      }
+    },
+
+    {
+
+      "subjects": {
+        "list": [
+          {
+            "name": "Genomics and evolutionary biology",
+            "url": "#"
+          },
+          {
+            "name": "Microbiology and Infectious Disease",
+            "url": "#"
+          }
+        ]
+      },
+      "title": "Evolutionary diversification of the trypanosome haptoglobin-haemoglobin receptor from an ancestral haemoglobin receptor",
+      "url": "#",
+      "secondaryInfo": "Harriet Lane-Serff et al.",
+      "footer": {
+        "meta": {
+          "text": "Research article",
+          "url": "#",
+          "date": {
+            "forHuman": {
+              "dayOfMonth": 16,
+              "month": "May",
+              "year": 2016
+            },
+            "forMachine": "2016-05-16"
+          }
+        },
+        "publishState": {
+          "vor": false
+        }
+      }
+    },
+
+    {
+      "subjects": {
+        "links": [
+          {
+            "name": "Epidemiology and Global Health",
+            "url": "#"
+          },
+          {
+            "name": "Microbiology and Infectious Disease",
+            "url": "#"
+          }
+        ]
+      },
+      "title": "The global antigenic diversity of swine influenza A viruses",
+      "url": "#",
+      "secondaryInfo": "Nicola S Lewis et al.",
+      "content": "Swine populations worldwide are sporadically infected by influenza viruses from humans and birds leading to geographically heterogeneous swine influenza virus populations that pose epizootic and pandemic threats.",
+      "footer": {
+        "meta": {
+          "text": "Research article",
+          "url": "#",
+          "date": {
+            "forHuman": {
+              "dayOfMonth": 15,
+              "month": "Apr",
+              "year": 2016
+            },
+            "forMachine": "2016-04-15"
+          }
+        },
+        "publishState": {
+          "vor": true
+        }
+      },
+      "image": {
+        "defaultPath": "http://unsplash.it/70/70/",
+        "srcset": "http://unsplash.it/140/140/ 140w, http://unsplash.it/70/70/ 70w",
+        "altText": "Meaningful alt text please.",
+        "classes": "teaser__img--small"
+      }
+    }
+  ],
+  "loadMore": {
+    "text": "Load more",
+    "path": "#"
+  }
+}

--- a/source/_patterns/04-pages/collection.json
+++ b/source/_patterns/04-pages/collection.json
@@ -190,6 +190,7 @@
 
   "mainTeasers": [
     {
+      "isTeaserType": true,
       "heading": "Collection",
       "items": [
         {
@@ -879,6 +880,7 @@
 
   "multimediaTeasers": [
     {
+      "isTeaserType": true,
       "heading": "Multimedia",
       "items": [
         {
@@ -913,6 +915,7 @@
 
   "relatedTeasers": [
     {
+      "isTeaserType": true,
       "heading": "Related",
       "items": [
         {
@@ -1014,6 +1017,7 @@
     }],
 
   "profileLinks": {
+    "isProfileSnippetType": true,
     "heading": "Contributors",
     "items": [
       {

--- a/source/_patterns/04-pages/collection.mustache
+++ b/source/_patterns/04-pages/collection.mustache
@@ -26,16 +26,7 @@
           <div class="grid__item large--eight-twelfths listing-column-main">
 
             {{#mainTeasers}}
-
-              {{> atoms-list-heading}}
-              <ol class="listing-list">
-                {{#items}}
-                  <li class="listing-list__item">
-                    {{> molecules-pl-only-teaser-main}}
-                  </li>
-                {{/items}}
-              </ol>
-
+              {{> organisms-list}}
             {{/mainTeasers}}
 
           </div>
@@ -43,44 +34,16 @@
           <div class="grid__item large--four-twelfths listing-column-secondary">
 
             {{#multimediaTeasers}}
-
-              {{> atoms-list-heading}}
-              <ol class="listing-list">
-                {{#items}}
-                  <li class="listing-list__item">
-                    {{> molecules-pl-only-teaser-secondary }}
-                  </li>
-                {{/items}}
-              </ol>
-
+              {{> organisms-list}}
             {{/multimediaTeasers}}
 
             {{#relatedTeasers}}
-
-              {{> atoms-list-heading}}
-              <ol class="listing-list">
-                {{#items}}
-                  <li class="listing-list__item">
-                    {{> molecules-pl-only-teaser-secondary }}
-                  </li>
-                {{/items}}
-              </ol>
-
+              {{> organisms-list}}
             {{/relatedTeasers}}
 
             {{#profileLinks}}
-
-              {{> atoms-list-heading}}
-              <ol class="listing-list">
-                {{#items}}
-                  <li class="listing-list__item">
-                    {{> molecules-profile-snippet }}
-                  </li>
-                {{/items}}
-              </ol>
-
+              {{> organisms-list}}
             {{/profileLinks}}
-
 
           </div>
 

--- a/source/_patterns/04-pages/msa.json
+++ b/source/_patterns/04-pages/msa.json
@@ -180,6 +180,7 @@
 
   "mainTeasers": [
     {
+      "isTeaserType": true,
       "heading": "Latest articles",
       "items": [
         {
@@ -222,7 +223,7 @@
         },
 
         {
-          "subjects": {
+          "contextLabel": {
             "list": [
               {
                 "name": "Epidemiology and Global Health",
@@ -258,7 +259,7 @@
 
         {
 
-          "subjects": {
+          "contextLabel": {
             "list": [
               {
                 "name": "Genomics and evolutionary biology",
@@ -293,7 +294,7 @@
         },
 
         {
-          "subjects": {
+          "contextLabel": {
             "links": [
               {
                 "name": "Epidemiology and Global Health",
@@ -335,9 +336,8 @@
         },
 
         {
-          "hasSubjects": "true",
 
-          "subjects": {
+          "contextLabel": {
             "list": [
               {
                 "name": "Ecology",
@@ -372,19 +372,19 @@
           }
         }
 
-      ]
+      ],
+      "loadMore": {
+        "type": "button",
+        "classes": "button--default button--full",
+        "text": "Load more",
+        "path": "#"
+      }
     }
   ],
 
-  "loadMore": {
-    "type": "button",
-    "classes": "button--default button--full",
-    "text": "Load more",
-    "path": "#"
-  },
-
   "secondaryTeasers": [
     {
+      "isTeaserType": true,
       "heading": "Highlighted content",
       "items": [
         {
@@ -496,7 +496,7 @@
 
         {
           "rootClasses": "teaser--secondary",
-          "subjects": {
+          "contextLabel": {
             "list": [
               {
                 "name": "Biophysics and Structural Biology",
@@ -539,6 +539,7 @@
   ],
 
   "profileLinks": {
+    "isProfileSnippetType": true,
     "heading": "Senior editors",
     "items": [
       {
@@ -579,12 +580,11 @@
           }
         }
       }
-    ]
-  },
-
-  "editorsMoreLink": {
-    "url": "#",
-    "name": "editors for Microbiology and Infectious Disease"
+    ],
+    "seeMoreLink": {
+      "url": "#",
+      "name": "See more editors for Microbiology and Infectious Disease"
+    }
   },
 
   "mainMenuLinks": [

--- a/source/_patterns/04-pages/msa.mustache
+++ b/source/_patterns/04-pages/msa.mustache
@@ -26,56 +26,20 @@
           <div class="grid__item large--eight-twelfths listing-column-main">
 
             {{#mainTeasers}}
-
-              {{> atoms-list-heading}}
-              <ol class="listing-list">
-                {{#items}}
-                  <li class="listing-list__item">
-                    {{> molecules-pl-only-teaser-main}}
-                  </li>
-                {{/items}}
-              </ol>
-
+              {{> organisms-listing}}
             {{/mainTeasers}}
 
-            {{#loadMore}}
-              {{> molecules-load-more}}
-            {{/loadMore}}
           </div>
 
           <div class="grid__item large--four-twelfths listing-column-secondary">
 
             {{#secondaryTeasers}}
-
-              {{> atoms-list-heading}}
-              <ol class="listing-list">
-                {{#items}}
-                  <li class="listing-list__item">
-                    {{> molecules-pl-only-teaser-secondary }}
-                  </li>
-                {{/items}}
-              </ol>
-
+              {{> organisms-listing}}
             {{/secondaryTeasers}}
 
             {{#profileLinks}}
-
-              {{> atoms-list-heading}}
-              <ol class="listing-list">
-                {{#items}}
-                  <li class="listing-list__item">
-                    {{> molecules-profile-snippet }}
-                  </li>
-                {{/items}}
-                {{#editorsMoreLink}}
-                  <li class="listing-list__item">
-                    {{> atoms-see-more-link}}
-                  </li>
-                {{/editorsMoreLink}}
-              </ol>
-
+              {{> organisms-listing}}
             {{/profileLinks}}
-
 
           </div>
 


### PR DESCRIPTION
UPDATE: prerequisites are in place, tests are passing. No longer WIP.

Proposed `listing` pattern.

This is WIP because:
1.  waiting to get confirmation from Nick that teasers and profile snippets are the only two types of entity that appear in a listing
2. `listing.yaml` references the `teaser.yaml` that has not landed yet (Stephen's working on it).

Currently it will be red be due to the outstanding `teaser.yaml`.
