### PR TITLE
Use inline style on iframe

### DIFF
--- a/assets/sass/patterns/atoms/iframe.scss
+++ b/assets/sass/patterns/atoms/iframe.scss
@@ -2,7 +2,6 @@
 
 .iframe {
   position: relative;
-  padding-bottom: 56.25%;
   height: 0;
   overflow: hidden;
   max-width: 100%;

--- a/source/_patterns/00-atoms/components/iframe.json
+++ b/source/_patterns/00-atoms/components/iframe.json
@@ -1,4 +1,4 @@
 {
-  "id": "id",
-  "src": "https://www.youtube.com/embed/6j0jRXPvpCE"
+  "src": "https://www.youtube.com/embed/6j0jRXPvpCE",
+  "paddingBottom": 56.25
 }

--- a/source/_patterns/00-atoms/components/iframe.mustache
+++ b/source/_patterns/00-atoms/components/iframe.mustache
@@ -1,3 +1,3 @@
-<div class="iframe iframe--{{id}}">
+<div class="iframe" style="padding-bottom: {{paddingBottom}}%">
     <iframe src="{{src}}" {{#allowFullScreen}}allowfullscreen{{/allowFullScreen}}></iframe>
 </div>

--- a/source/_patterns/00-atoms/components/iframe.yaml
+++ b/source/_patterns/00-atoms/components/iframe.yaml
@@ -6,15 +6,15 @@ schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object
   properties:
-    id:
-      type: string
-      minLength: 1
     src:
       type: string
       minLength: 1
     allowFullScreen:
       type: boolean
       default: false
+    paddingBottom:
+      type: number # (height/width)×100
+      minimum: 1
   required:
-    - id
     - src
+    - paddingBottom

--- a/source/_patterns/04-pages/article--research.json
+++ b/source/_patterns/04-pages/article--research.json
@@ -361,8 +361,8 @@
   ],
 
   "iframe": {
-    "id": "id",
-    "src": "https://www.youtube.com/embed/6j0jRXPvpCE"
+    "src": "https://www.youtube.com/embed/6j0jRXPvpCE",
+    "paddingBottom": 56.25
   },
 
 


### PR DESCRIPTION
The only place where an implementation has to add extra styles currently is in the iframe pattern. This makes it an inline style instead.
