### PR TITLE
Uglify js in production (only)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -197,8 +197,8 @@ gulp.task('js', ['js:hint', 'js:cs', 'browserify-tests'], () => {
           .pipe(source('main.js'))
           .pipe(buffer())
 
-          // (optional) uglify final file
-          // .pipe(uglify())
+          //uglify output for production
+          .pipe(environment === 'production' ? uglify() : gutil.noop())
 
           // sourcemaps
           .pipe(sourcemaps.init({loadMaps: true}))


### PR DESCRIPTION
Reinstate uglifying js when Gulp build invoked with the `--environment production` argument.
