### PR TITLE
Fix time regex

### DIFF
--- a/source/_patterns/01-molecules/teasers/media-chapter-listing-item.yaml
+++ b/source/_patterns/01-molecules/teasers/media-chapter-listing-item.yaml
@@ -15,7 +15,7 @@ schema:
           minValue: 0
         forHuman:
           type: string
-          pattern: ^([1-9]?[0-9]:){0,2}[1-9]?[0-9]$
+          pattern: ^([1-9][0-9]*|0):[0-5][0-9]$
     chapterNumber:
       type: integer
       minValue: 1


### PR DESCRIPTION
Currently doesn't pass valid times like `0:00`, but does pass invalid times like `2:2` and `4:89`. This should fix it.
