### PR TITLE
Loosen audio player media type requirement

### DIFF
--- a/source/_patterns/01-molecules/components/audio-player.yaml
+++ b/source/_patterns/01-molecules/components/audio-player.yaml
@@ -26,11 +26,7 @@ schema:
             properties:
               forMachine:
                 type: string
-                enum:
-                  - audio/mp3
-                  - audio/mpeg
-                  - audio/webm
-                  - audio/ogg
+                pattern: ^(audio\/[a-zA-Z0-9!#$%^&\*_\-\+{}\|'.`~]+)(; *[a-zA-Z0-9!#$%^&\*_\-\+{}\|'.`~]+=(([a-zA-Z0-9\.\-]+)|(".+")))*$
               forHuman:
                 type: string
                 minLength: 1


### PR DESCRIPTION
Requirement is now any `audio/` type. Plus it allows the possibility of parameters (not that we plan to use any).
