### PR TITLE
Fix bug in media-source

### DIFF
--- a/source/_patterns/00-atoms/components/media-source.mustache
+++ b/source/_patterns/00-atoms/components/media-source.mustache
@@ -1,4 +1,4 @@
-<source src="{{src}}" type="{{mimeType.forMachine}}" class="media-source"/>
+<source src="{{src}}" type='{{mimeType.forMachine}}' class="media-source"/>
 
 <div>
 

--- a/source/_patterns/00-atoms/components/media-source.yaml
+++ b/source/_patterns/00-atoms/components/media-source.yaml
@@ -27,6 +27,10 @@ schema:
       properties:
         forMachine:
           type: string
+          # Note that any codec subattribute of forMachine must be specified with double quotes, not single quotes. The
+          # mustache file has the type attribute set within single quotes to accommodate this, so the final HTML result
+          # should end up looking like this (but with differing values as appropriate):
+          #   type='video/webm; codecs="vp8.0, vorbis"'
           pattern: ^(audio)|(video)\/.+$
         forHuman:
           type: string

--- a/source/_patterns/00-atoms/components/video.json
+++ b/source/_patterns/00-atoms/components/video.json
@@ -4,21 +4,21 @@
     {
       "src": "https://static-movie-usa.glencoesoftware.com/mp4/10.7554/872/946920eb226e045af1781fe292f2cd5206b30a75/elife-14093-app2-media1.mp4",
       "mimeType": {
-        "forMachine": "video/mp4; codecs='avc1.42E01E, mp4a.40.2'",
+        "forMachine": "video/mp4; codecs=\"avc1.42E01E, mp4a.40.2\"",
         "forHuman": "mp4"
       }
     },
     {
       "src": "https://static-movie-usa.glencoesoftware.com/webm/10.7554/872/946920eb226e045af1781fe292f2cd5206b30a75/elife-14093-app2-media1.webm",
       "mimeType": {
-        "forMachine": "video/webm; codecs='vp8.0, vorbis'",
+        "forMachine": "video/webm; codecs=\"vp8.0, vorbis\"",
         "forHuman": "webm"
       }
     },
     {
       "src": "https://static-movie-usa.glencoesoftware.com/ogv/10.7554/872/946920eb226e045af1781fe292f2cd5206b30a75/elife-14093-app2-media1.ogv",
       "mimeType": {
-        "forMachine": "video/ogg; codecs='theora, vorbis'",
+        "forMachine": "video/ogg; codecs=\"theora, vorbis\"",
         "forHuman": "ogg"
       }
     }


### PR DESCRIPTION
Change quotes for handling type attribute so codecs can be specified with double quotes.
