### PR TITLE
view-selector: update jumpLinks occurrences add property for side by side link

### DIFF
--- a/source/_patterns/01-molecules/navigation/view-selector.json
+++ b/source/_patterns/01-molecules/navigation/view-selector.json
@@ -1,13 +1,16 @@
 {
-  "articleUrl": "#",
-  "figureUrl": "#",
-  "jumpLinks": [
-    { "name": "Abstract", "url": "#abstract" },
-    { "name": "eLife digest", "url": "#digest" },
-    { "name": "Introduction", "url": "#introduction" },
-    { "name": "Results", "url": "#results" },
-    { "name": "Discussion", "url": "#discussion" },
-    { "name": "Materials & methods", "url": "#materials-and-methods" },
-    { "name": "References", "url": "#references" }
-  ]
+  "articleUrl": "#article",
+  "figureUrl": "#figures",
+  "sideBySideUrl": "#sideBySide",
+  "jumpLinks": {
+    "links": [
+      { "name": "Abstract", "url": "#abstract" },
+      { "name": "eLife digest", "url": "#digest" },
+      { "name": "Introduction", "url": "#introduction" },
+      { "name": "Results", "url": "#results" },
+      { "name": "Discussion", "url": "#discussion" },
+      { "name": "Materials & methods", "url": "#materials-and-methods" },
+      { "name": "References", "url": "#references" }
+    ]
+  }
 }

--- a/source/_patterns/01-molecules/navigation/view-selector.mustache
+++ b/source/_patterns/01-molecules/navigation/view-selector.mustache
@@ -1,5 +1,4 @@
-
-<div class="view-selector" data-behaviour="ViewSelector">
+<div class="view-selector" data-behaviour="ViewSelector"{{#sideBySideUrl}} data-side-by-side-link="{{sideBySideUrl}}"{{/sideBySideUrl}}>
   <ul class="view-selector__list">
     <li class="view-selector__list-item view-selector__list-item--article view-selector__list-item--active">
       <a href="{{articleUrl}}" class="view-selector__link view-selector__link--article"><i class="icon"></i><span>Article</span></a>
@@ -9,15 +8,19 @@
         <a href="{{figureUrl}}" class="view-selector__link view-selector__link--figures"><i class="icon"></i><span>Figures</span></a>
       </li>
     {{/figureUrl}}
-    <li class="view-selector__list-item view-selector__list-item--jump">
-      <span class="view-selector__jump_links_header">Jump to</span>
-      <ul class="view-selector__jump_links" data-behaviour="DropDown">
-        {{#jumpLinks}}
-          <li class="view-selector__jump_link_item">
-            <a href="{{url}}" class="view-selector__jump_link">{{name}}</a>
-          </li>
-        {{/jumpLinks}}
-      </ul>
-    </li>
+
+    {{#jumpLinks}}
+      <li class="view-selector__list-item view-selector__list-item--jump">
+        <span class="view-selector__jump_links_header">Jump to</span>
+        <ul class="view-selector__jump_links" data-behaviour="DropDown">
+          {{#links}}
+            <li class="view-selector__jump_link_item">
+              <a href="{{url}}" class="view-selector__jump_link">{{name}}</a>
+            </li>
+          {{/links}}
+        </ul>
+      </li>
+    {{/jumpLinks}}
+
   </ul>
 </div>

--- a/source/_patterns/01-molecules/navigation/view-selector.yaml
+++ b/source/_patterns/01-molecules/navigation/view-selector.yaml
@@ -6,6 +6,9 @@ schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object
   properties:
+    sideBySideUrl:
+      type: string
+      minLength: 1
     articleUrl:
       type: string
       minLength: 1
@@ -13,20 +16,24 @@ schema:
       type: string
       minLength: 1
     jumpLinks:
-      type: array
-      minItems: 1
-      items:
-        type: object
-        properties:
-          name:
-            type: string
-            minLength: 1
-          url:
-            type: string
-            minLength: 1
-        required:
-          - name
-          - url
+      type: object
+      properties:
+        links:
+          type: array
+          minItems: 2
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+                minLength: 1
+              url:
+                type: string
+                minLength: 1
+            required:
+              - name
+              - url
+      required:
+        - links
   required:
     - articleUrl
-    - jumpLinks


### PR DESCRIPTION
New property `sideBySideUrl` that will be used by the js to provide link to the side by side view.

`jumpLinks` is now optional, and must contain a minimum of 2 links when present.
