### PR TITLE
Update DOI presentation for all but the article-level reflexive DOI

### DIFF
--- a/source/_patterns/00-atoms/components/doi.mustache
+++ b/source/_patterns/00-atoms/components/doi.mustache
@@ -1,1 +1,1 @@
-<span class="doi{{#variant}} doi--{{variant}}{{/variant}}">doi: <a href="https://doi.org/{{doi}}" class="doi__link">{{doi}}</a></span>
+<span class="doi{{#variant}} doi--{{variant}}{{/variant}}">doi: <a href="https://doi.org/{{doi}}" class="doi__link">{{^hidePrefix}}https://doi.org/{{/hidePrefix}}{{doi}}</a></span>

--- a/source/_patterns/00-atoms/components/doi.yaml
+++ b/source/_patterns/00-atoms/components/doi.yaml
@@ -13,5 +13,9 @@ schema:
       type: string
       enum:
         - article-section
+    hidePrefix:
+      type: boolean
+      default:
+        - false
   required:
     - doi

--- a/source/_patterns/00-atoms/components/doi~hidden-prefix.json
+++ b/source/_patterns/00-atoms/components/doi~hidden-prefix.json
@@ -1,0 +1,4 @@
+{
+  "doi": "10.7554/eLife.16370",
+  "hidePrefix": true
+}

--- a/source/_patterns/01-molecules/components/contextual-data.json
+++ b/source/_patterns/01-molecules/components/contextual-data.json
@@ -22,7 +22,8 @@
     "citeAs": "eLife 2016;5:e16370",
     "doi": {
       "class": "contextual-data__doi",
-      "doi": "10.7554/eLife.16370"
+      "doi": "10.7554/eLife.16370",
+      "hidePrefix": true
     }
   }
 

--- a/source/_patterns/04-pages/article--research.json
+++ b/source/_patterns/04-pages/article--research.json
@@ -328,7 +328,8 @@
       "citeAs": "eLife 2016;5:e16370",
       "doi": {
         "class": "contextual-data__doi",
-        "doi": "10.7554/eLife.16370"
+        "doi": "10.7554/eLife.16370",
+        "hidePrefix": true
       }
     }
 


### PR DESCRIPTION
Adds new property `hidePrefix` to be set true when DOI is used inside contextual-data. 