### PR TITLE
Fix ORCID regex

### DIFF
--- a/source/_patterns/00-atoms/components/author-details.yaml
+++ b/source/_patterns/00-atoms/components/author-details.yaml
@@ -51,7 +51,7 @@ schema:
       properties:
         id:
           type: string
-          pattern: ^([0-9]{4}-){3}[0-9]{4}$
+          pattern: ^([0-9]{4}-){3}[0-9]{3}[0-9X]$
         icon:
           type: object
           properties:


### PR DESCRIPTION
Last character is a checksum, which can be 'X'.