### PR TITLE
Allow for HTML in the competing interests statement

### DIFF
--- a/source/_patterns/00-atoms/components/author-details.mustache
+++ b/source/_patterns/00-atoms/components/author-details.mustache
@@ -50,7 +50,7 @@
 
   <section class="author-details__section author-details__section--competing-interest">
     <h5 class="author-details__heading">Competing interests: </h5>
-    <span class="author-details__text">{{competingInterest}}</span>
+    <span class="author-details__text">{{{competingInterest}}}</span>
   </section>
 
   {{#orcid}}


### PR DESCRIPTION
Some competing interests statements have HTML (eg `Reviewing editor, <i>eLife</i>.`).