### PR TITLE
Make reference origin optional

### DIFF
--- a/source/_patterns/00-atoms/references/reference.yaml
+++ b/source/_patterns/00-atoms/references/reference.yaml
@@ -39,6 +39,7 @@ schema:
                 - name
     origin:
       type: string
+      minLength: 1
     hasAbstracts:
       type: boolean
     abstracts:


### PR DESCRIPTION
We have legacy (broken) references that won't have a value (see https://github.com/elifesciences/api-raml/blob/develop/src/misc/reference.v1.yaml#L478-L503).