### PR TITLE
Fix bug and some js perf improvement

### DIFF
--- a/assets/js/components/ViewSelector.js
+++ b/assets/js/components/ViewSelector.js
@@ -13,8 +13,9 @@ module.exports = class ViewSelector {
     this.$elm = $elm;
     this.$jumpLinks = this.$elm.querySelector('.view-selector__jump_links');
     this.$jumpLinksToggle = this.$elm.querySelector('.view-selector__jump_links_header');
-
     this.cssFixedClassName = 'view-selector--fixed';
+
+    this.mainTarget = this.doc.querySelector('[role="main"]');
 
     // matches top padding in scss
     let topSpaceWhenFixed = 30;
@@ -30,21 +31,33 @@ module.exports = class ViewSelector {
     // If it's position is fixed
     if (this.$elm.classList.contains(this.cssFixedClassName)) {
 
-      let bottomOfMain = this.doc.querySelector('[role="main"]').getBoundingClientRect().bottom;
-
       // Allow it to scroll again if it could keep its position & not scroll off top of screen
       if (this.window.pageYOffset < this.elmYOffset) {
         this.$elm.classList.remove(this.cssFixedClassName);
-
-      // Allow it to scroll again if it would otherwise over-/under-lay following element
-      } else if (bottomOfMain < this.$elm.offsetHeight) {
-        let amountToNudgeUp = bottomOfMain - this.$elm.offsetHeight;
-        this.$elm.style.top = amountToNudgeUp + 'px';
+        return;
       }
 
+      // Allow it to scroll again if it would otherwise over-/under-lay following element
+      let bottomOfMain = this.mainTarget.getBoundingClientRect().bottom;
+      if (bottomOfMain < this.$elm.offsetHeight) {
+        let amountToNudgeUp = bottomOfMain - this.$elm.offsetHeight;
+        this.$elm.style.top = amountToNudgeUp + 'px';
+        return;
+      }
+
+      // Ensure top of component is not off top of screen once bottom of main is off screen bottom
+      // Safety net: required because a fast scroll may prevent all code running as desired.
+      if (bottomOfMain >= this.window.innerHeight) {
+        this.$elm.style.top = '0px';
+      }
+
+      return;
+    }
+
     // Otherwise fix its position if it would otherwise scroll off the top of the screen
-    } else if (this.window.pageYOffset >= this.elmYOffset) {
+    if (this.window.pageYOffset >= this.elmYOffset) {
       this.$elm.classList.add(this.cssFixedClassName);
+      this.$elm.style.top = '0px';
     }
 
   }


### PR DESCRIPTION
Allows view-selector to come fully back on screen when appropriate, even when fast scroll potentially prevents correct reporting of values.

Performance improvements to the handleScroll method.