### PR TITLE
Restrict inline image height to the text height

### DIFF
--- a/assets/sass/_mixins.scss
+++ b/assets/sass/_mixins.scss
@@ -264,3 +264,7 @@
   }
 }
 
+@mixin inline-image {
+  margin-bottom: -3px;
+  height: 1em;
+}

--- a/assets/sass/_normalize-overrides.scss
+++ b/assets/sass/_normalize-overrides.scss
@@ -123,3 +123,9 @@ address {
 img {
   max-width: 100%;
 }
+
+h1, h2, h3, h4, h5, h6, p {
+  img {
+    @include inline-image();
+  }
+}

--- a/assets/sass/patterns/atoms/author-details.scss
+++ b/assets/sass/patterns/atoms/author-details.scss
@@ -44,6 +44,5 @@ a.author-details__link {
 }
 
 .author-details__linked-image--orcid {
-  margin-bottom: -3px;
-  @include height($font-size-base-in-px);
+  @include inline-image();
 }

--- a/assets/sass/patterns/atoms/caption-text.scss
+++ b/assets/sass/patterns/atoms/caption-text.scss
@@ -7,11 +7,11 @@
 
 // May contain arbitrary html. Might need to refine if too blunt an instrument.
 .caption-text__body,
-.caption-text__body * {
+.caption-text__body > * {
   @include fig-caption-text-typeg(0);
   font-weight: normal;
 }
 
-.caption-text__body * {
+.caption-text__body > * {
   @include body-spacing();
 }

--- a/assets/sass/patterns/organisms/box.scss
+++ b/assets/sass/patterns/organisms/box.scss
@@ -35,7 +35,7 @@
   }
 
   .caption-text__body,
-  .caption-text__body * {
+  .caption-text__body > * {
     @include font-size($font-size-caption-in-px * $box-font-scaling-factor);
   }
 


### PR DESCRIPTION
Images inside text are a problem. Currently these images are just included as is, leading to:

<img width="650" alt="screen shot 2017-01-04 at 15 08 37" src="https://cloud.githubusercontent.com/assets/1784740/21646836/cc0b81f2-d28f-11e6-9923-46dbd41966da.png">

This restricts them to the height of the text:

<img width="547" alt="screen shot 2017-01-04 at 15 08 46" src="https://cloud.githubusercontent.com/assets/1784740/21646842/cd69213a-d28f-11e6-8dba-8414df73c757.png">

This doesn't attempt to resize images inside other elements (eg `<td>`, `<li>`), as they're likely not text-height (or we have no way of determining it).