### PR TITLE
Simplify pager requirements

### DIFF
--- a/source/_patterns/01-molecules/navigation/pager.yaml
+++ b/source/_patterns/01-molecules/navigation/pager.yaml
@@ -11,17 +11,8 @@ schema:
       $ref: ../../00-atoms/components/button.yaml#/schema
     nextPage:
       $ref: ../../00-atoms/components/button.yaml#/schema
-  oneOf:
-    - required:
-      - nextPage
-      not:
-        required:
-          - previousPage
+  anyOf:
     - required:
       - previousPage
-      not:
-        required:
-          - nextPage
     - required:
       - nextPage
-      - previousPage


### PR DESCRIPTION
Using `not` allows you to say 'this one is required and this one must _not_ be present', but here we just need 'one of these must be present'.