### PR TITLE
ELPP-1999 Fix expanded date line height

### DIFF
--- a/assets/sass/patterns/atoms/date.scss
+++ b/assets/sass/patterns/atoms/date.scss
@@ -23,6 +23,7 @@
 
   .date__prominent {
     @include font-size(36);
+    line-height: 1;
     text-align: center;
     @include padding(10, "top");
   }


### PR DESCRIPTION
#418 had added a `line-height` to the `__label-typeg()` mixin.