### PR TITLE
Add indicator while pager data is loading

### DIFF
--- a/assets/sass/_mixins.scss
+++ b/assets/sass/_mixins.scss
@@ -206,6 +206,30 @@
 
 }
 
+@mixin loading-spinner($torus-width: 5, $size: 22,
+                       $highlight-color: $color-primary, $base-color: rgba(255, 255, 255, 0.2)) {
+  animation: full-rotation 1.1s infinite linear;
+  border: #{$torus-width}px solid $base-color;
+  border-left: #{$torus-width}px solid $highlight-color;
+  border-radius: 50%;
+  display: block;
+  height: #{$size}px;
+  overflow: hidden;
+  text-indent: -9999em;
+  transform: translateZ(0);
+  width: #{$size}px;
+
+  @keyframes full-rotation {
+    0% {
+      transform: rotate(0deg);
+    }
+    100% {
+      transform: rotate(360deg);
+    }
+  }
+
+}
+
 @mixin nospace($direction: "all") {
   @if $direction == "all" {
     margin: 0;

--- a/assets/sass/patterns/molecules/audio-player.scss
+++ b/assets/sass/patterns/molecules/audio-player.scss
@@ -20,32 +20,11 @@
   top: 0;
   @include width(90);
 
-  // Quick & dirty loading spinner, happy to swap this out for something better.
   &.loading {
-    animation: load8 1.1s infinite linear;
-    border: 5px solid rgba(255, 255, 255, 0.2);
-    border-left: 5px solid $color-primary;
+    @include loading-spinner();
     left: 30px;
-    overflow: hidden;
-    text-indent: -9999em;
-    top: 25px;
-    transform: translateZ(0);
-  }
+    top: 22px;
 
-  &.loading,
-  &.loading:after {
-    border-radius: 50%;
-    width: 22px;
-    height: 22px;
-  }
-
-  @keyframes load8 {
-    0% {
-      transform: rotate(0deg);
-    }
-    100% {
-      transform: rotate(360deg);
-    }
   }
 
 }

--- a/assets/sass/patterns/molecules/pager.scss
+++ b/assets/sass/patterns/molecules/pager.scss
@@ -7,3 +7,18 @@
 .button:nth-child(2) {
   float: right;
 }
+
+.js .pager__text_wrapper.loading {
+
+  position: relative;
+
+  &:after {
+    @include loading-spinner($highlight-color: $color-text--reverse, $base-color: #81c4e8);
+    content: "";
+    display: inline-block;
+    position: relative;
+    left: 6px;
+    top: 4px;
+  }
+
+}


### PR DESCRIPTION
This includes a timeout threshold, beyond which the page will redirect to the full results page. Currently the threshold is set for 10 seconds.

The loading spinner in used for the audio player has been abstracted out into a mixin so it can be used here as well (and anywhere else we might want to use it).