### PR TITLE
Explicitly set dependent packages as optional to avoid crash in npm 3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
     "uglify-js": "^2.6.4",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0"
+  },
+  "optionalDependencies": {
+    "fsevents": "*"
   }
 }


### PR DESCRIPTION
I'll spare you the details, but with the latest version of npm the build stops working, at least on Linux and hence CI, because of https://github.com/npm/npm/issues/14042