### PR TITLE
Experimental: trigger update-patterns-php

### DIFF
--- a/Jenkinsfile.prod
+++ b/Jenkinsfile.prod
@@ -9,5 +9,5 @@ elifePipeline {
     builderDeployRevision 'pattern-library--prod', commit
 
     stage 'Downstream'
-    build job: 'update-patterns-php', wait: false
+    build job: 'dependencies-patterns-php-update-pattern-library', wait: false
 }


### PR DESCRIPTION
This should asynchronously trigger another pipeline after a new update (and deploy) to `master`. The success of this pipeline `prod-pattern-library` does not depend on the success of the downstream one being triggered, since we are not even waiting for it to start.