### PR TITLE
ELPP-2239 Allow archive nav link to not have any links

### DIFF
--- a/source/_patterns/01-molecules/components/archive-nav-link.json
+++ b/source/_patterns/01-molecules/components/archive-nav-link.json
@@ -8,24 +8,5 @@
       "lowResImageSource": "https://unsplash.it/950/400",
       "highResImageSource": "https://unsplash.it/1900/800"
     }
-  },
-  "label": "Highlights this month:",
-  "links": [
-    {
-      "name": "Exploring the ins and outs of breathing",
-      "url": "#Exploring"
-    },
-    {
-      "name": "The ancient origins of lubricated joints",
-      "url": "#The"
-    },
-    {
-      "name": "Modulating protein quality control",
-      "url": "#Modulating"
-    },
-    {
-      "name": "How open science helps researchers succeed",
-      "url": "#How"
-    }
-  ]
+  }
 }

--- a/source/_patterns/01-molecules/components/archive-nav-link.mustache
+++ b/source/_patterns/01-molecules/components/archive-nav-link.mustache
@@ -4,11 +4,13 @@
     {{> atoms-block-link}}
   {{/blockLink}}
 
+  {{#label}}
   <dl class="archive-nav-link__list">
     <dt class="archive-nav-link__sub_links_list_heading">{{{label}}}</dt>
     {{#links}}
       <dd class="archive-nav-link__sub_links_list_item"><a class="archive-nav-link__sub_link" href="{{url}}">{{{name}}}</a></dd>
     {{/links}}
   </dl>
+  {{/label}}
 
 </div>

--- a/source/_patterns/01-molecules/components/archive-nav-link.yaml
+++ b/source/_patterns/01-molecules/components/archive-nav-link.yaml
@@ -29,7 +29,6 @@ schema:
           - url
   required:
     - blockLink
-    - links
-
-
-
+  dependencies:
+    label: [links]
+    links: [label]

--- a/source/_patterns/01-molecules/components/archive-nav-link~with-links.json
+++ b/source/_patterns/01-molecules/components/archive-nav-link~with-links.json
@@ -1,0 +1,31 @@
+{
+  "url": "#",
+  "blockLink": {
+    "url": "#",
+    "text": "Developmental Biology and Stem Cells",
+    "behaviour": "BackgroundImage",
+    "backgroundImage": {
+      "lowResImageSource": "https://unsplash.it/950/400",
+      "highResImageSource": "https://unsplash.it/1900/800"
+    }
+  },
+  "label": "Highlights this month:",
+  "links": [
+    {
+      "name": "Exploring the ins and outs of breathing",
+      "url": "#Exploring"
+    },
+    {
+      "name": "The ancient origins of lubricated joints",
+      "url": "#The"
+    },
+    {
+      "name": "Modulating protein quality control",
+      "url": "#Modulating"
+    },
+    {
+      "name": "How open science helps researchers succeed",
+      "url": "#How"
+    }
+  ]
+}


### PR DESCRIPTION
In the event we don't have the data.

Also added a dependency between `label` and `links`.