### PR TITLE
Added bin/dev command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,21 @@ You'll need:
 
 Then install compass: `gem install compass`
 
+## 2. Automatic setup
+From the root directory run
+```
+$ ./bin/dev
+```
+This will install and run the commands needed to get started, starting a web server on port 8889. If you need a custom port pass this as the first argument:
+```
+$ ./bin/dev 1234
+```
+This will run on localhost:1234 
+
+You should be good to go, open your browser and you will see the pattern lab.
+
+# Manual setup
+
 ## 1. Set up PatternLab
 
 - Clone pattern library: `git clone git@github.com:elifesciences/pattern-library.git`

--- a/bin/dev
+++ b/bin/dev
@@ -7,6 +7,7 @@ if [ ! -d ./public ]; then
   cp -r ./core/styleguide ./public/
 fi
 
+PORT=${1:-8889}
 
 echo "Building patterns..."
 gulp
@@ -17,12 +18,12 @@ PID_LIST+=" $pid";
 php ./core/builder.php --watch > /dev/null 2>&1 & pid=$!
 PID_LIST+=" $pid";
 
-php -S 0.0.0.0:8889 -t ./public > /dev/null 2>&1 & pid=$!
+php -S 0.0.0.0:${PORT} -t ./public > /dev/null 2>&1 & pid=$!
 PID_LIST+=" $pid";
 
 trap "kill ${PID_LIST}" SIGINT
 
-echo "Running Pattern Library at http://localhost:8889/";
+echo "Running Pattern Library at http://localhost:${PORT}/";
 wait ${PID_LIST}
 echo
 echo "Stopping pattern library, gulp and server.";


### PR DESCRIPTION
@davidcmoulton  @scottgemmell 

Based on feedback from Scott, I've added a single command that will run the 3 commands needed to get up and running. I've tested pulling the repository from scratch, I got up and running just by running:
```
$ ./bin/dev
```
If there is no public folder it will run `npm install`, copy over the directories needed and then start running the normal tasks (gulp, gulp watch, pattern library watch and the webserver).