### PR TITLE
ELPP-1799 Don't drop down to assets in paths

### DIFF
--- a/assets/sass/patterns/atoms/additional-asset.scss
+++ b/assets/sass/patterns/atoms/additional-asset.scss
@@ -16,11 +16,11 @@ a.additional-asset__link {
 .additional-asset__link--download {
   color: $color-text;
   padding-left: 30px;
-  background: transparent url("../../assets/img/icons/download-2x.png") 0 50% no-repeat;
+  background: transparent url("../img/icons/download-2x.png") 0 50% no-repeat;
   background-size: 20px;
 
   &:hover {
-    background-image: url("../../assets/img/icons/download-hover.png");
+    background-image: url("../img/icons/download-hover.png");
   }
 
 }

--- a/assets/sass/patterns/molecules/teaser.scss
+++ b/assets/sass/patterns/molecules/teaser.scss
@@ -199,16 +199,16 @@
   }
 
   .teaser__download {
-    background: url("../../assets/img/icons/download.png") 50% 50% no-repeat;
-    background: url("../../assets/img/icons/download.svg") 50% 50% no-repeat, linear-gradient(transparent, transparent);
+    background: url("../img/icons/download.png") 50% 50% no-repeat;
+    background: url("../img/icons/download.svg") 50% 50% no-repeat, linear-gradient(transparent, transparent);
     display: inline-block;
     float: right;
     @include height(20);
     @include width(20);
 
     &:hover {
-      background: url("../../assets/img/icons/download-hover.png") 50% 50% no-repeat;
-      background: url("../../assets/img/icons/download-hover.svg") 50% 50% no-repeat, linear-gradient(transparent, transparent);
+      background: url("../img/icons/download-hover.png") 50% 50% no-repeat;
+      background: url("../img/icons/download-hover.svg") 50% 50% no-repeat, linear-gradient(transparent, transparent);
     }
   }
 }


### PR DESCRIPTION
Means the top level directory can't be called anything other than `assets`.

Only other place I can see this happening is in `AudioPlayer.js`, but that's a bigger issue.