### PR TITLE
Add asset rewrite to listing teasers

### DIFF
--- a/source/_patterns/02-organisms/components/listing-teasers.mustache
+++ b/source/_patterns/02-organisms/components/listing-teasers.mustache
@@ -18,14 +18,14 @@
       <span class="visuallyhidden">Highlights controls:</span>
       <button class="highlights__control highlights__control--prev">
         <picture>
-          <source srcset="{{assetsPath}}/img/patterns/molecules/chevron-left-ic.svg" type="image/svg+xml">
-          <img src="{{assetsPath}}/img/patterns/molecules/chevron-left-ic_1x.png" srcset="{{assetsPath}}/img/patterns/molecules/chevron-left-ic_2x.png 48w, {{assetsPath}}/img/patterns/molecules/chevron-left-ic_1x.png 24w" alt="Previous">
+          <source srcset="{{#assetRewrite}}{{assetsPath}}/img/patterns/molecules/chevron-left-ic.svg{{/assetRewrite}}" type="image/svg+xml">
+          <img src="{{#assetRewrite}}{{assetsPath}}/img/patterns/molecules/chevron-left-ic_1x.png{{/assetRewrite}}" srcset="{{#assetRewrite}}{{assetsPath}}/img/patterns/molecules/chevron-left-ic_2x.png{{/assetRewrite}} 48w, {{#assetRewrite}}{{assetsPath}}/img/patterns/molecules/chevron-left-ic_1x.png{{/assetRewrite}} 24w" alt="Previous">
         </picture>
       </button>
       <button class="highlights__control highlights__control--next">
         <picture>
-          <source srcset="{{assetsPath}}/img/patterns/molecules/chevron-right-ic.svg" type="image/svg+xml">
-          <img src="{{assetsPath}}/img/patterns/molecules/chevron-right-ic_1x.png" srcset="{{assetsPath}}/img/patterns/molecules/chevron-right-ic_2x.png 48w, {{assetsPath}}/img/patterns/molecules/chevron-right-ic_1x.png 24w" alt="Next">
+          <source srcset="{{#assetRewrite}}{{assetsPath}}/img/patterns/molecules/chevron-right-ic.svg{{/assetRewrite}}" type="image/svg+xml">
+          <img src="{{#assetRewrite}}{{assetsPath}}/img/patterns/molecules/chevron-right-ic_1x.png{{/assetRewrite}}" srcset="{{#assetRewrite}}{{assetsPath}}/img/patterns/molecules/chevron-right-ic_2x.png{{/assetRewrite}} 48w, {{#assetRewrite}}{{assetsPath}}/img/patterns/molecules/chevron-right-ic_1x.png{{/assetRewrite}} 24w" alt="Next">
         </picture>
       </button>
     </p>


### PR DESCRIPTION
Due to PRs being merged around the same time the new requirement was missed from #536.