### PR TITLE
Make search box obey main page grid when on main search page

### DIFF
--- a/assets/sass/patterns/molecules/search-box.scss
+++ b/assets/sass/patterns/molecules/search-box.scss
@@ -14,6 +14,12 @@
   max-width: #{$max-site-width}px;
   padding: 0 6%;
   position: relative;
+
+  .wrapper & {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
 }
 
 .search-box__output {


### PR DESCRIPTION
Sets up the CSS classes used by `journal` in https://github.com/elifesciences/journal/pull/527