### PR TITLE
Ignore fragments that won't work with querySelector()

### DIFF
--- a/assets/js/components/Popup.js
+++ b/assets/js/components/Popup.js
@@ -3,7 +3,7 @@ const utils = require('../libs/elife-utils')();
 module.exports = class Popup {
 
   constructor($elm, _window = window, doc = document) {
-    if (!$elm.hash || $elm.host !== _window.location.host) {
+    if (!$elm.hash || $elm.host !== _window.location.host || !$elm.hash.match(/^#[a-z]/i)) {
       return;
     }
 


### PR DESCRIPTION
`querySelector()` doesn't understand HTML5 IDs, so breaks if they begin with a number etc.