### PR TITLE
Remove enforced reference author link

### DIFF
--- a/source/_patterns/00-atoms/references/reference.mustache
+++ b/source/_patterns/00-atoms/references/reference.mustache
@@ -24,8 +24,7 @@
     <ol class="reference__authors_list">
       {{#authors}}
         <li class="reference__author">
-            {{! Allowing for arbitrary link, with fallback link to Google Scholar if missing. (Anticipating eLife profile links, but TBC.) }}
-            <a href="{{#url}}{{{url}}}{{/url}}{{^url}}http://scholar.google.com/scholar?q=&quot;author:{{{name}}}&quot;{{/url}}" class="reference__authors_link" target="_blank">{{{name}}}</a>{{!
+          {{#url}}<a href="{{url}}" class="reference__authors_link">{{/url}}{{{name}}}{{#url}}</a>{{/url}}{{!
         }}</li>
       {{/authors}}
     </ol>

--- a/source/_patterns/00-atoms/references/reference~journal-article.json
+++ b/source/_patterns/00-atoms/references/reference~journal-article.json
@@ -6,7 +6,8 @@
     {
       "authors": [
         {
-          "name": "Schrenk F"
+          "name": "Schrenk F",
+          "url": "https://scholar.google.com/scholar?q=%22author:Schrenk%20F%22"
         },
         {
           "name": "Bromage TG"


### PR DESCRIPTION
The HTML produced is invalid, the quote is wrong (should be percent encoded), as are spaces in author names. But I don't think this should be hard-coded in the pattern anyway.