### PR TITLE
Add grid-secondary-column__item

### DIFF
--- a/assets/sass/layout/_grid.scss
+++ b/assets/sass/layout/_grid.scss
@@ -101,6 +101,10 @@
   @include blg-column-container();
 }
 
+.grid-secondary-column__item {
+  @include blg-column-container();
+}
+
 /*
  *  Wrapper class. A class for constraining the content to the max-site-width and also applies the side padding.
  */

--- a/assets/sass/patterns/organisms/listing.scss
+++ b/assets/sass/patterns/organisms/listing.scss
@@ -1,5 +1,4 @@
 @import "../../definitions";
-@import "../../layout/grid";
 
 $showTwoAtWidth: #{get-rem-from-px($bkpt-site--wide)}rem;
 $showThreeAtWidth: #{get-rem-from-px($bkpt-site--x-wide)}rem;
@@ -20,10 +19,6 @@ $totalHighlightsSpacing: 6;
     margin-bottom: 0;
   }
 
-}
-
-.grid-secondary-column .listing-list {
-  @include blg-column-container();
 }
 
 .listing-list__item {


### PR DESCRIPTION
Currently padding is only correctly applied to items in the secondary column that are listing. Other things (such as the search filters) don't have it, so run into the footer on small screens.

This adds a new wrapper for all items that appear in the list. This isn't ideal as Journal will need to wrap all items.

(I haven't updated any pages here as they seem to have out of date grids.)