### PR TITLE
Do not build patterns-php versions of the PRs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,15 +15,6 @@ elifePipeline {
         }
     }
 
-    elifePullRequestOnly {
-        stage 'Downstream', {
-            build job: 'dependencies-patterns-php-update-pattern-library-pull-request', wait: false, parameters: [
-                string(name: 'pattern_library_branch', value: env.BRANCH_NAME),
-                string(name: 'pattern_library_commit', value: commit)
-            ]
-        }
-    }
-
     elifeMainlineOnly {
         stage 'Approval', {
             elifeGitMoveToBranch commit, 'approved'


### PR DESCRIPTION
The downstream build has been removed as useless, so do not trigger it.

Could be urgent as PRs build may fail without this removal.