### PR TITLE
ELPP-2791 Only use MutationObserver if it's available

### DIFF
--- a/assets/js/components/Math.js
+++ b/assets/js/components/Math.js
@@ -11,14 +11,16 @@ module.exports = class Math {
 
   static init(doc) {
     Math.loadDependencies(doc);
-    if (!Math.dependenciesAlreadySetup(doc)) {
-      let observer = new MutationObserver((mutations, observer) => {
-        Math.loadDependencies(doc);
-        if (Math.dependenciesAlreadySetup(doc)) {
-          observer.disconnect();
-        }
-      });
-      observer.observe(doc.body, { childList: true, subtree: true });
+    if ('MutationObserver' in window) {
+      if (!Math.dependenciesAlreadySetup(doc)) {
+        let observer = new MutationObserver((mutations, observer) => {
+          Math.loadDependencies(doc);
+          if (Math.dependenciesAlreadySetup(doc)) {
+            observer.disconnect();
+          }
+        });
+        observer.observe(doc.body, { childList: true, subtree: true });
+      }
     }
   }
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -5,7 +5,7 @@ require('./libs/polyfills');
 // Base level of feature support needed for the js loaded in this file.
 // Consider AJAXing in the rest if the test passes.
 if (window.localStorage && document.querySelector &&
-       window.addEventListener && !!(document.createElement('div')).classList) {
+       window.addEventListener && !!(document.createElement('div')).dataset) {
 
   document.querySelector('html').classList.add('js');
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -84,13 +84,15 @@ if (window.localStorage && document.querySelector &&
       [].forEach.call(components, (el) => initialiseComponent(el));
     }
 
-    let observer = new MutationObserver(() => {
-      let components = document.querySelectorAll('[data-behaviour]:not([data-behaviour-initialised])');
-      if (components) {
-        [].forEach.call(components, (el) => initialiseComponent(el));
-      }
-    });
-    observer.observe(document.body, { childList: true, subtree: true });
+    if ('MutationObserver' in window) {
+      let observer = new MutationObserver(() => {
+        let components = document.querySelectorAll('[data-behaviour]:not([data-behaviour-initialised])');
+        if (components) {
+          [].forEach.call(components, (el) => initialiseComponent(el));
+        }
+      });
+      observer.observe(document.body, { childList: true, subtree: true });
+    }
   };
 
   new Elife();


### PR DESCRIPTION
Decided not to block AssetNavigation, means that any captions containing MathML will probably appear un-MathJaxed. Given that we haven't addressed non-JS MathML anyhow, let's just live with it.