### PR TITLE
ELPP-2789 Link First Author et al to details section (narrow)

### DIFF
--- a/assets/sass/patterns/organisms/content-header.scss
+++ b/assets/sass/patterns/organisms/content-header.scss
@@ -398,13 +398,29 @@
   }
 }
 
+// Displays First Author et al. when narrow only.
+.content-header__authors--line {
+  @include author-typeg();
+  display: none;
+
+  @media only all and (max-width: #{get-rem-from-px($bkpt-site--medium)}em) {
+    display: block;
+  }
+
+  .content-header__author_link:hover {
+    color: $color-text;
+  }
+
+}
+
+.content-header__author_link_highlight,
+.content-header__author_link_highlight:hover {
+  color: $color-primary;
+}
+
 .content-header__authors {
   @include margin($content-header-padding, "bottom");
   @media only all and (max-width: #{get-rem-from-px($bkpt-site--medium)}em) {
-    &:before {
-      content: attr(data-author-line);
-      @include author-typeg();
-    }
     .content-header__author_list {
       @include visuallyhidden();
     }

--- a/assets/sass/patterns/organisms/content-header.scss
+++ b/assets/sass/patterns/organisms/content-header.scss
@@ -38,11 +38,11 @@
   height: #{$content-header-image-height--narrow-screen}px;
   overflow: hidden;
 
-  @media only all and (min-width: #{get-rem-from-px($bkpt-content-header--medium-width)}em) {
+  @media only all and (min-width: #{get-rem-from-px($bkpt-site--medium)}em) {
     height: #{$content-header-image-height--medium-width-screen}px;
   }
 
-  @media only all and (min-width: #{get-rem-from-px($bkpt-content-header--wide)}em) {
+  @media only all and (min-width: #{get-rem-from-px($bkpt-site--wide)}em) {
     height: #{$content-header-image-height--wide-screen}px;
   }
 
@@ -60,7 +60,7 @@
       @include padding(0 48);
     }
 
-    @media only all and (min-width: #{get-rem-from-px($bkpt-content-header--wide)}em) {
+    @media only all and (min-width: #{get-rem-from-px($bkpt-site--wide)}em) {
       height: #{$content-header-padding * 7}px;
     }
   }
@@ -72,7 +72,7 @@
 
   .content-header--header & {
     @include margin($content-header-padding * 1.5 + 11 * 2.1818181818, "top"); // 11 * 2.1818181818 is the height of the subject line
-    @media only all and (min-width: #{get-rem-from-px($bkpt-content-header--medium-width)}em) {
+    @media only all and (min-width: #{get-rem-from-px($bkpt-site--medium)}em) {
       @include margin($content-header-padding * 2 + 11 * 2.1818181818, "top");
     }
   }
@@ -84,12 +84,12 @@
   @include margin(0, "top");
   @include margin(0, "bottom");
 
-  @media only all and (min-width: #{get-rem-from-px($bkpt-content-header--medium-width)}em) {
+  @media only all and (min-width: #{get-rem-from-px($bkpt-site--medium)}em) {
     @include font-size(41);
     line-height: 1.1707317073; /* 48px with 41px font size */
   }
 
-  @media only all and (min-width: #{get-rem-from-px($bkpt-content-header--wide)}em) {
+  @media only all and (min-width: #{get-rem-from-px($bkpt-site--wide)}em) {
     @include font-size(46);
     line-height: 1.5652173913;
   }
@@ -98,7 +98,7 @@
   .content-header--read-more & {
     @include font-size(29);
     line-height: 1.2413793103;
-    @media only all and (min-width: #{get-rem-from-px($bkpt-content-header--medium-width)}em) {
+    @media only all and (min-width: #{get-rem-from-px($bkpt-site--medium)}em) {
       @include font-size(36);
       line-height: 1.3333333333;
     }
@@ -115,7 +115,7 @@
   .content-header__body {
     @include margin($content-header-padding * 2, "top");
 
-    @media only all and (min-width: #{get-rem-from-px($bkpt-content-header--medium-width)}em) {
+    @media only all and (min-width: #{get-rem-from-px($bkpt-site--medium)}em) {
       @include margin($content-header-padding * 3, "top");
     }
 
@@ -125,11 +125,11 @@
     @include font-size(41);
     line-height: 1.1707317073;
 
-    @media only all and (min-width: #{get-rem-from-px($bkpt-content-header--medium-width)}em) {
+    @media only all and (min-width: #{get-rem-from-px($bkpt-site--medium)}em) {
       @include font-size(52);
     }
 
-    @media only all and (min-width: #{get-rem-from-px($bkpt-content-header--wide)}em) {
+    @media only all and (min-width: #{get-rem-from-px($bkpt-site--wide)}em) {
       @include font-size(58);
       line-height: 1.2413793103; /* 72px with 58px font size */
     }
@@ -138,11 +138,11 @@
   .content-header__title--long {
     @include font-size(36);
 
-    @media only all and (min-width: #{get-rem-from-px($bkpt-content-header--medium-width)}em) {
+    @media only all and (min-width: #{get-rem-from-px($bkpt-site--medium)}em) {
       @include font-size(41);
     }
 
-    @media only all and (min-width: #{get-rem-from-px($bkpt-content-header--wide)}em) {
+    @media only all and (min-width: #{get-rem-from-px($bkpt-site--wide)}em) {
       @include font-size(46);
     }
   }
@@ -218,7 +218,7 @@
 }
 
 @supports (display: flex) {
-  @media only all and (min-width: #{get-rem-from-px($bkpt-content-header--medium-width)}em) {
+  @media only all and (min-width: #{get-rem-from-px($bkpt-site--medium)}em) {
     .content-header__profile--has-image {
       display: inline-flex;
       justify-content: center;
@@ -334,18 +334,18 @@
   right: 7%;
   top: 24px;
 
-  @media only all and (min-width: #{get-rem-from-px($bkpt-content-header--medium-width)}em) {
+  @media only all and (min-width: #{get-rem-from-px($bkpt-site--medium)}em) {
     right: 14%;
     top: 14px;
   }
 
-  @media only all and (min-width: #{get-rem-from-px($bkpt-content-header--extra-wide)}em) {
+  @media only all and (min-width: #{get-rem-from-px($bkpt-site--x-wide)}em) {
     right: 42px;
   }
 
   .content-header--image & {
 
-    @media only all and (min-width: #{get-rem-from-px($bkpt-content-header--extra-wide)}em) {
+    @media only all and (min-width: #{get-rem-from-px($bkpt-site--x-wide)}em) {
       right: 16px;
     }
 
@@ -361,7 +361,7 @@
 .content-header__download_icon {
   width: #{$content-header-download-width}px;
 
-  @media only all and (min-width: #{get-rem-from-px($bkpt-content-header--medium-width)}em) {
+  @media only all and (min-width: #{get-rem-from-px($bkpt-site--medium)}em) {
     width: #{$content-header-download-width-medium}px;
   }
 
@@ -388,7 +388,7 @@
   .content-header--image & {
     @include margin(0, "bottom");
     display: none;
-    @media only all and (min-width: #{get-rem-from-px($bkpt-content-header--wide)}em) {
+    @media only all and (min-width: #{get-rem-from-px($bkpt-site--wide)}em) {
       display: block;
     }
   }
@@ -400,7 +400,7 @@
 
 .content-header__authors {
   @include margin($content-header-padding, "bottom");
-  @media only all and (max-width: #{get-rem-from-px($bkpt-content-header--medium-width)}em) {
+  @media only all and (max-width: #{get-rem-from-px($bkpt-site--medium)}em) {
     &:before {
       content: attr(data-author-line);
       @include author-typeg();
@@ -497,7 +497,7 @@ li.content-header__institution_list_item--last .content-header__institution:afte
   content: "";
 }
 
-@media only all and (min-width: #{get-rem-from-px($bkpt-content-header--medium-width)}em) {
+@media only all and (min-width: #{get-rem-from-px($bkpt-site--medium)}em) {
 
   .content-header__author--last-non-excess:after {
     content: "";

--- a/assets/sass/patterns/organisms/content-header.scss
+++ b/assets/sass/patterns/organisms/content-header.scss
@@ -401,10 +401,14 @@
 // Displays First Author et al. when narrow only.
 .content-header__authors--line {
   @include author-typeg();
-  display: none;
 
-  @media only all and (max-width: #{get-rem-from-px($bkpt-site--medium)}em) {
-    display: block;
+  .content-header:not(.content-header--read-more) & {
+    display: none;
+
+    @media only all and (max-width: #{get-rem-from-px($bkpt-site--medium)}em) {
+      display: block;
+    }
+
   }
 
   .content-header__author_link:hover {

--- a/source/_patterns/02-organisms/content-headers/content-header.mustache
+++ b/source/_patterns/02-organisms/content-headers/content-header.mustache
@@ -127,12 +127,6 @@
     </div>
   {{/authors}}
 
-  {{^authors}}
-    {{#authorLine}}
-      <div class="content-header__authors content-header__authors--line">{{{authorLine}}}</div>
-    {{/authorLine}}
-  {{/authors}}
-
   {{#button}}
     <div class="content-header__cta">
       {{>atoms-button}}

--- a/source/_patterns/02-organisms/content-headers/content-header.mustache
+++ b/source/_patterns/02-organisms/content-headers/content-header.mustache
@@ -100,7 +100,7 @@
   </div>
 
   {{#authors}}
-    <div class="content-header__authors" data-author-line="{{authorLine}}">
+    <div class="content-header__authors">
       <ol class="content-header__author_list">
         {{#authors.list}}
           <li class="content-header__author_list_item">
@@ -126,6 +126,19 @@
       {{/institutions}}
     </div>
   {{/authors}}
+
+  {{! authorLine used to link to main article author section when narrow }}
+  {{#authorLine}}
+    <!-- aria-hidden because this is just a short summary for narrow viewports, the full author list should be accessible -->
+    <div class="content-header__authors content-header__authors--line" aria-hidden="true">
+      {{#url}}
+        <a href="{{url}}" class="content-header__author_link">{{{text}}}{{#hasEtAl}}<span class="content-header__author_link_highlight">  et al.</span>{{/hasEtAl}}</a>
+      {{/url}}
+      {{^url}}
+        {{{text}}}
+      {{/url}}
+    </div>
+  {{/authorLine}}
 
   {{#button}}
     <div class="content-header__cta">

--- a/source/_patterns/02-organisms/content-headers/content-header.yaml
+++ b/source/_patterns/02-organisms/content-headers/content-header.yaml
@@ -70,8 +70,20 @@ schema:
         hasProfile: [profile]
         profile: [hasProfile]
     authorLine:
-      type: string
-      minLength: 1
+      type: object
+      properties:
+        text:
+          type: string
+          minLength: 1
+        url:
+          type: string
+          minLength: 1
+        hasEtAl:
+          type: boolean
+          enum:
+            - true
+      required:
+        - text
     authors:
       type: object
       properties:

--- a/source/_patterns/02-organisms/content-headers/content-header.yaml
+++ b/source/_patterns/02-organisms/content-headers/content-header.yaml
@@ -122,4 +122,5 @@ schema:
     - title
   dependencies:
     authorLine: [authors]
+    authors: [authorLine]
     institutions: [authors]

--- a/source/_patterns/02-organisms/content-headers/content-header~article.json
+++ b/source/_patterns/02-organisms/content-headers/content-header~article.json
@@ -20,7 +20,11 @@
     ]
   },
   "download": "#download",
-  "authorLine": "Lee R Berger et al",
+  "authorLine": {
+    "text": "Lee R Berger",
+    "hasEtAl": true,
+    "url": "#"
+  },
   "authors": {
     "list": [
       {

--- a/source/_patterns/04-pages/article--charts.json
+++ b/source/_patterns/04-pages/article--charts.json
@@ -138,7 +138,11 @@
         }
       ]
     },
-    "authorLine": "Lee R Berger et al",
+    "authorLine": {
+      "text": "Lee R Berger",
+      "hasEtAl": true,
+      "url": "#"
+    },
     "authors": {
       "list": [
         {"name": "Lee R Berger"},

--- a/source/_patterns/04-pages/article--figures.json
+++ b/source/_patterns/04-pages/article--figures.json
@@ -127,7 +127,11 @@
         }
       ]
     },
-    "authorLine": "Lee R Berger et al",
+    "authorLine": {
+      "text": "Lee R Berger",
+      "hasEtAl": true,
+      "url": "#"
+    },
     "authors": {
       "list": [
         {
@@ -740,7 +744,11 @@
               "url": "#"
             }
           ],
-          "authorLine": "Lee R Berger et al",
+          "authorLine": {
+            "text": "Lee R Berger",
+            "hasEtAl": true,
+            "url": "#"
+          },
           "meta": {
             "url": "#",
             "text": "Research article",
@@ -771,7 +779,11 @@
               "url": "#"
             }
           ],
-          "authorLine": "Lee R Berger et al",
+          "authorLine": {
+            "text": "Lee R Berger",
+            "hasEtAl": true,
+            "url": "#"
+          },
           "meta": {
             "url": "#",
             "text": "Research article",

--- a/source/_patterns/04-pages/article--magazine.json
+++ b/source/_patterns/04-pages/article--magazine.json
@@ -138,7 +138,10 @@
         }
       ]
     },
-    "authorLine": "Melanie Issigonis and Phillip A Newmark",
+    "authorLine": {
+      "text": "Melanie Issigonis, Phillip A Newmark",
+      "url": "#"
+    },
     "authors": {
       "list": [
         {"name": "Melanie Issigonis"},

--- a/source/_patterns/04-pages/article--press-pack~has-related-has-jumplinks.json
+++ b/source/_patterns/04-pages/article--press-pack~has-related-has-jumplinks.json
@@ -140,7 +140,10 @@
         }
       ]
     },
-    "authorLine": "Melanie Issigonis and Phillip A Newmark",
+    "authorLine": {
+      "text": "Melanie Issigonis, Phillip A Newmark",
+      "url": "#"
+    },
     "authors": {
       "list": [
         {"name": "Melanie Issigonis"},

--- a/source/_patterns/04-pages/article--press-pack~has-related-no-jumplinks.json
+++ b/source/_patterns/04-pages/article--press-pack~has-related-no-jumplinks.json
@@ -140,7 +140,10 @@
         }
       ]
     },
-    "authorLine": "Melanie Issigonis and Phillip A Newmark",
+    "authorLine": {
+      "text": "Melanie Issigonis, Phillip A Newmark",
+      "url": "#"
+    },
     "authors": {
       "list": [
         {"name": "Melanie Issigonis"},

--- a/source/_patterns/04-pages/article--press-pack~without-related-nor-jump-links.json
+++ b/source/_patterns/04-pages/article--press-pack~without-related-nor-jump-links.json
@@ -138,7 +138,10 @@
         }
       ]
     },
-    "authorLine": "Melanie Issigonis and Phillip A Newmark",
+    "authorLine": {
+      "text": "Melanie Issigonis, Phillip A Newmark",
+      "url": "#"
+    },
     "authors": {
       "list": [
         {"name": "Melanie Issigonis"},

--- a/source/_patterns/04-pages/article--press-pack~without-related.json
+++ b/source/_patterns/04-pages/article--press-pack~without-related.json
@@ -139,7 +139,10 @@
         }
       ]
     },
-    "authorLine": "Melanie Issigonis and Phillip A Newmark",
+    "authorLine": {
+      "text": "Melanie Issigonis, Phillip A Newmark",
+      "url": "#"
+    },
     "authors": {
       "list": [
         {"name": "Melanie Issigonis"},

--- a/source/_patterns/04-pages/article--research.json
+++ b/source/_patterns/04-pages/article--research.json
@@ -130,7 +130,11 @@
         }
       ]
     },
-    "authorLine": "Lee R Berger et al",
+    "authorLine": {
+      "text": "Lee R Berger",
+      "hasEtAl": true,
+      "url": "#articleInfo"
+    },
     "authors": {
       "list": [
         {
@@ -731,7 +735,7 @@
               "url": "#"
             }
           ],
-          "authorLine": "Lee R Berger et al",
+          "authorLine": "Lee R Berger et al.",
           "meta": {
             "url": "#",
             "text": "Research article",
@@ -762,7 +766,7 @@
               "url": "#"
             }
           ],
-          "authorLine": "Lee R Berger et al",
+          "authorLine": "Lee R Berger et al.",
           "meta": {
             "url": "#",
             "text": "Research article",


### PR DESCRIPTION
- Make `authorLine` content populate a real DOM element, for use on narrow view
- Enable linking of the author line, and account for flag to indicate whether "et al." should also be shown.

@thewilkybarkid: this will require changes to `patterns-php`, let me know if you see anything in here that may cause problems with that.