### PR TITLE
Restrict universal selector to top level

### DIFF
--- a/assets/sass/patterns/atoms/caption-text.scss
+++ b/assets/sass/patterns/atoms/caption-text.scss
@@ -7,7 +7,7 @@
 
 // May contain arbitrary html. Might need to refine if too blunt an instrument.
 .caption-text__body,
-.caption-text__body * {
+.caption-text__body > * {
   @include fig-caption-text-typeg(0);
   font-weight: normal;
 
@@ -21,7 +21,7 @@
 
 }
 
-.caption-text__body * {
+.caption-text__body > * {
   @include body-spacing();
 }
 


### PR DESCRIPTION
Stops it bleeding into MathJax etc (switch to CommonHTML). May have side effects.