### PR TITLE
ELPP-2907 Remove padding from et al link

### DIFF
--- a/assets/sass/patterns/organisms/content-header.scss
+++ b/assets/sass/patterns/organisms/content-header.scss
@@ -452,6 +452,10 @@ $iconlist: cc oa;
   }
 }
 
+.content-header__author_link_highlight {
+  padding: 0;
+}
+
 .content-header__author_link_highlight,
 .content-header__author_link_highlight:hover {
   background-color: transparent;
@@ -550,10 +554,6 @@ li.content-header__institution_list_item--last .content-header__institution:afte
 }
 
 .content-header__item_toggle--expanded {
-
-  .content-header__author_link_highlight {
-    padding: 0;
-  }
 
   & .content-header__item_toggle_cta {
     display: block;

--- a/source/_patterns/02-organisms/content-headers/content-header.mustache
+++ b/source/_patterns/02-organisms/content-headers/content-header.mustache
@@ -112,14 +112,19 @@
 
   {{#authors}}
     <div class="content-header__authors">
-      <ol class="content-header__author_list">{{#authors.list}}<li class="content-header__author_list_item">
+      <ol class="content-header__author_list">
+        {{#authors.list}}
+          <li class="content-header__author_list_item">
             <span class="content-header__author">{{#url}}<a href="{{url}}" data-behaviour="Popup" class="content-header__author_link">{{/url}}{{name}}{{#url}}</a>{{/url}}{{#isCorresponding}}
               <picture>
                <source srcset="{{#assetRewrite}}{{assetsPath}}/img/icons/corresponding-author.svg{{/assetRewrite}}" type="image/svg+xml">
                <img src="{{#assetRewrite}}{{assetsPath}}/img/icons/corresponding-author@1x.png{{/assetRewrite}}"
                     srcset="{{#assetRewrite}}{{assetsPath}}/img/icons/corresponding-author@2x.png{{/assetRewrite}} 20w, {{#assetRewrite}}{{assetsPath}}/img/icons/corresponding-author@1x.png{{/assetRewrite}} 10w"
                     sizes="10px" alt="Is a corresponding author" class="content-header__author_icon">
-              </picture>{{/isCorresponding}}</span></li>{{/authors.list}}</ol>
+              </picture>{{/isCorresponding}}</span>
+          </li>
+        {{/authors.list}}
+      </ol>
 
       {{#institutions}}
         <ol class="content-header__institution_list">


### PR DESCRIPTION
I didn't realise in #706 that the et al button doesn't have defined padding, and that iOS had a default that's a lot bigger (my mistake for not checking). So, this removes the padding and reverts #706 so that there's a space beforehand. The difference now is that the hit target is just the text, the same as a normal link.