### PR TITLE
Make honeypot field not tab accessible

### DIFF
--- a/source/_patterns/00-atoms/forms/honeypot.mustache
+++ b/source/_patterns/00-atoms/forms/honeypot.mustache
@@ -1,3 +1,15 @@
 <div class="visuallyhidden" aria-hidden="true">
-  {{>atoms-text-field}}
+
+  {{#label}}
+    <label for="{{id}}" class="form-label">{{labelText}}</label>
+  {{/label}}
+  <input
+      type="{{inputType}}"
+      class="text-field text-field--{{inputType}}"
+    {{#id}} id="{{id}}"{{/id}}
+    {{#name}} name="{{name}}"{{/name}}
+    {{#value}} value="{{value}}"{{/value}}
+      tabindex="-1"
+  />
+
 </div>


### PR DESCRIPTION
This change completes #708.

Uses a cut-down version of the text field template, but importantly adds `tabindex="-1"`.