### PR TITLE
Tidy up article toggle

### DIFF
--- a/assets/sass/patterns/molecules/view-selector.scss
+++ b/assets/sass/patterns/molecules/view-selector.scss
@@ -130,11 +130,13 @@
   .view-selector__list-item--article {
     border-right: none;
     @include border-radius-simple(4, 0, 0, 4);
+    width: 170px;
   }
 
   .view-selector__list-item--figures {
     border-left: none;
     @include border-radius-simple(0, 4, 4, 0);
+    width: 170px;
   }
 
   .view-selector__list-item--active {

--- a/assets/sass/patterns/molecules/view-selector.scss
+++ b/assets/sass/patterns/molecules/view-selector.scss
@@ -116,10 +116,10 @@
 
   .view-selector__list {
     margin: auto;
+    border-bottom: 1px solid $color-text-dividers;
   }
 
   .view-selector__list-item {
-    border: 1px solid $color-text;
     float: left;
     margin: 0;
     @include padding(0 18);
@@ -127,30 +127,19 @@
   }
 
   /** Selector nesting here because otherwise this all gets horrible quickly **/
-  .view-selector__list-item--article {
-    border-right: none;
-    @include border-radius-simple(4, 0, 0, 4);
-    width: 170px;
-  }
-
-  .view-selector__list-item--figures {
-    border-left: none;
-    @include border-radius-simple(0, 4, 4, 0);
-    width: 170px;
-  }
-
   .view-selector__list-item--active {
-    background-color: $color-text;
     font-weight: 700;
+    border: 1px solid $color-text-dividers;
+    border-bottom: 1px solid $color-text-ui-background;
+    padding-bottom: 1px;
+    margin-bottom: -1px;
 
     .view-selector__link {
-      color: $color-text-ui-background;
       font-weight: 700;
 
       &:hover {
         cursor: default;
       }
-
     }
   }
 
@@ -164,20 +153,15 @@
 
   .view-selector__link {
     line-height: 2.5714285714; /* 36px at 14px font size */
+    color: $color-text-placeholder;
     @include height(34);
     @include nospace();
     text-align: center;
-    text-transform: uppercase;
 
     span {
       padding: 0;
     }
   }
-
-  .view-selector__link--figures {
-    color: $color-text;
-  }
-
 }
 
 @media only screen and (min-width: #{get-rem-from-px($bkpt-view-selector)}em) {

--- a/assets/sass/patterns/molecules/view-selector.scss
+++ b/assets/sass/patterns/molecules/view-selector.scss
@@ -123,14 +123,13 @@
   .view-selector__list-item {
     float: left;
     margin: 0;
-    @include padding(0 24);
+    padding: 0;
     text-align: center;
   }
 
   .view-selector__list-item {
     float: left;
     margin: 0;
-    @include padding(0 24);
     text-align: center;
 
     &:hover {
@@ -184,7 +183,10 @@
     line-height: 2.875; /* 46px at 16px font size */
     color: $color-text-placeholder;
     @include height(46);
-    @include nospace();
+    display: block;
+
+    @include padding(0 24);
+    @include margin(0);
     @include font-size(16);
     text-align: center;
 

--- a/assets/sass/patterns/molecules/view-selector.scss
+++ b/assets/sass/patterns/molecules/view-selector.scss
@@ -115,6 +115,7 @@
   }
 
   .view-selector__list {
+    width: 100%;
     margin: auto;
     border-bottom: 1px solid $color-text-dividers;
     @supports (display: flex) {
@@ -125,9 +126,8 @@
   }
 
   .view-selector__list-item {
-    float: left;
     margin: 0;
-    @include padding(0 18);
+    @include padding(0 24);
     text-align: center;
   }
 
@@ -136,7 +136,6 @@
     font-weight: 700;
     border: 1px solid $color-text-dividers;
     border-bottom: 1px solid $color-text-ui-background;
-    padding-bottom: 1px;
     margin-bottom: -1px;
 
     .view-selector__link {
@@ -157,10 +156,11 @@
   }
 
   .view-selector__link {
-    line-height: 2.5714285714; /* 36px at 14px font size */
+    line-height: 2.875; /* 46px at 16px font size */
     color: $color-text-placeholder;
-    @include height(34);
+    @include height(46);
     @include nospace();
+    @include font-size(16);
     text-align: center;
 
     span {

--- a/assets/sass/patterns/molecules/view-selector.scss
+++ b/assets/sass/patterns/molecules/view-selector.scss
@@ -158,14 +158,14 @@
 
   /** Selector nesting here because otherwise this all gets horrible quickly **/
   .view-selector__list-item--active {
-    font-weight: 700;
     border: 1px solid $color-text-dividers;
-    border-bottom: 1px solid $color-text-ui-background;
+    border-bottom-color: $color-text-ui-background;
+    font-weight: 700;
     margin-bottom: -1px;
 
     &:hover {
       border: 1px solid $color-text-dividers;
-      border-bottom: 1px solid $color-text-ui-background;
+      border-bottom-color: $color-text-ui-background;
     }
 
     .view-selector__link {

--- a/assets/sass/patterns/molecules/view-selector.scss
+++ b/assets/sass/patterns/molecules/view-selector.scss
@@ -132,6 +132,8 @@
   }
 
   .view-selector__list-item {
+    border: 1px solid $color-text--reverse;
+    border-bottom: none;
     float: left;
     margin: 0;
     text-align: center;
@@ -147,7 +149,7 @@
   }
 
   .view-selector__list-item--article {
-    margin-left: 24px;
+    margin-left: 12px;
   }
 
   .view-selector__list-item--figures {
@@ -185,7 +187,7 @@
 
   .view-selector__link {
     line-height: 2.875; /* 46px at 16px font size */
-    color: $color-text-placeholder;
+    color: $color-text-secondary;
     @include height(46);
     display: block;
 

--- a/assets/sass/patterns/molecules/view-selector.scss
+++ b/assets/sass/patterns/molecules/view-selector.scss
@@ -117,6 +117,11 @@
   .view-selector__list {
     margin: auto;
     border-bottom: 1px solid $color-text-dividers;
+    @supports (display: flex) {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    }
   }
 
   .view-selector__list-item {

--- a/assets/sass/patterns/molecules/view-selector.scss
+++ b/assets/sass/patterns/molecules/view-selector.scss
@@ -118,17 +118,37 @@
     width: 100%;
     margin: auto;
     border-bottom: 1px solid $color-text-dividers;
-    @supports (display: flex) {
-      display: flex;
-      justify-content: center;
-      align-items: center;
-    }
   }
 
   .view-selector__list-item {
+    float: left;
     margin: 0;
     @include padding(0 24);
     text-align: center;
+  }
+
+  .view-selector__list-item {
+    float: left;
+    margin: 0;
+    @include padding(0 24);
+    text-align: center;
+
+    &:hover {
+      border: 1px solid $color-text-dividers;
+      border-bottom: none;
+
+      .view-selector__link {
+        color: $color-text;
+      }
+    }
+  }
+
+  .view-selector__list-item--article {
+    margin-left: 24px;
+  }
+
+  .view-selector__list-item--figures {
+    margin-left: 8px;
   }
 
   /** Selector nesting here because otherwise this all gets horrible quickly **/
@@ -137,6 +157,11 @@
     border: 1px solid $color-text-dividers;
     border-bottom: 1px solid $color-text-ui-background;
     margin-bottom: -1px;
+
+    &:hover {
+      border: 1px solid $color-text-dividers;
+      border-bottom: 1px solid $color-text-ui-background;
+    }
 
     .view-selector__link {
       font-weight: 700;


### PR DESCRIPTION
Started as equal widths but turned into a tabbed menu. There may be some more variables that can be referenced in the CSS in place of hardcoded values, or `em` values, or Sass mixins.

Notable points:
- `ul` now expands to 100% width to provide bottom border
- `li` are still floated and align to the left with some margins
- the active `li` has a white border moved to delete out the one from the `ul`
` `li` are still hovered in the non-active version to show the clickable area with borders
- `a` elements now expand to the whole of their `li` container so that the largest possible area can be clicked
- currently active `a` is bold, hovered one is black but not bold (determined by hovering over the larger `li`, not itself)

<img src="https://user-images.githubusercontent.com/160299/28320947-d8161164-6bc9-11e7-9bf8-11ba4066863a.png" width="200" />
<img src="https://user-images.githubusercontent.com/160299/28320946-d8100030-6bc9-11e7-987f-6492ead93777.png" width="200" />
