### PR TITLE
ELPP-1965: jump menu highlighting based on page scroll

### DIFF
--- a/assets/js/components/ViewSelector.js
+++ b/assets/js/components/ViewSelector.js
@@ -14,7 +14,7 @@ module.exports = class ViewSelector {
     this.window = _window;
     this.doc = doc;
     this.$elm = $elm;
-    this.$jumpLinks = this.$elm.querySelector('.view-selector__jump_links');
+    this.$jumpLinksList = this.$elm.querySelector('.view-selector__jump_links');
     this.$jumpLinksToggle = this.$elm.querySelector('.view-selector__jump_links_header');
     this.cssFixedClassName = 'view-selector--fixed';
 
@@ -80,11 +80,10 @@ module.exports = class ViewSelector {
       this.$elm.classList.add(this.cssFixedClassName);
       this.$elm.style.top = '0px';
     }
-
   }
 
   toggleJumpLinks() {
-    this.$jumpLinks.classList.toggle('visuallyhidden');
+    this.$jumpLinksList.classList.toggle('visuallyhidden');
     this.$jumpLinksToggle.classList.toggle('view-selector__jump_links_header--closed');
     this.handleScroll();
 

--- a/assets/js/components/ViewSelector.js
+++ b/assets/js/components/ViewSelector.js
@@ -107,10 +107,14 @@ module.exports = class ViewSelector {
     if ($section && typeof $section.id === 'string') {
       const $target = ViewSelector.findLinkToHighlight(this.$jumpLinksList, `[href="#${$section.id}"]`);
       if ($target) {
-        ViewSelector.clearJumpLinkHighlight(this.jumpLinks);
-        ViewSelector.highlightJumpLink($target);
+        ViewSelector.updateHighlighting($target, this.jumpLinks);
       }
     }
+  }
+
+  static updateHighlighting($target, jumpLinksList) {
+    ViewSelector.clearJumpLinkHighlight(jumpLinksList);
+    ViewSelector.highlightJumpLink($target);
   }
 
   static findSectionForLinkHighlight($heading, firstHeadingText, findClosest) {
@@ -127,8 +131,8 @@ module.exports = class ViewSelector {
     return findClosest.call(null, $heading, '.article-section').previousElementSibling;
   }
 
-  static clearJumpLinkHighlight($jumpLinksList) {
-    const linksList = [].slice.call($jumpLinksList);
+  static clearJumpLinkHighlight(jumpLinksList) {
+    const linksList = [].slice.call(jumpLinksList);
     linksList.forEach(($link) => {
       $link.classList.remove('view-selector__jump_link--active');
     });

--- a/assets/js/components/ViewSelector.js
+++ b/assets/js/components/ViewSelector.js
@@ -15,8 +15,11 @@ module.exports = class ViewSelector {
     this.doc = doc;
     this.$elm = $elm;
     this.$jumpLinksList = this.$elm.querySelector('.view-selector__jump_links');
+    this.jumpLinks = this.$elm.querySelectorAll('.view-selector__jump_link');
     this.$jumpLinksToggle = this.$elm.querySelector('.view-selector__jump_links_header');
     this.cssFixedClassName = 'view-selector--fixed';
+    this.collapsibleSectionHeadings = this.doc.querySelectorAll(
+      '[data-behaviour="ArticleSection"] > .article-section__header .article-section__header_text');
 
     if (this.sideBySideViewAvailable()) {
       const $header = this.doc.querySelector('#siteHeader');
@@ -48,7 +51,49 @@ module.exports = class ViewSelector {
   }
 
   handleScroll() {
+    this.handlePositioning();
+    this.handleHighlighting();
+  }
 
+  handleHighlighting() {
+    const $firstViewableSectionHeading = this.findFirstInView(this.collapsibleSectionHeadings);
+    if (!$firstViewableSectionHeading) {
+      return;
+    }
+
+    const $section = utils.closest($firstViewableSectionHeading, '.article-section');
+    if ($section && typeof $section.id === 'string') {
+      const $toHighlight = this.$elm.querySelector(`[href="#${$section.id}"]`);
+      if ($toHighlight) {
+        [].forEach.call(this.jumpLinks, ($jumpLink) => {
+          $jumpLink.classList.remove('view-selector__jump_link--active');
+        });
+        $toHighlight.classList.add('view-selector__jump_link--active');
+      }
+    }
+  }
+
+  /**
+   * Returns the first HTMLElement in the list that is in view
+   * @param elementList{NodeList|Array}
+   * @returns {(HTMLElement|null)}
+   */
+  findFirstInView(elementList) {
+    // Ensure elements is an array
+    const elements = [].slice.call(elementList);
+    let $found = null;
+    elements.forEach(($el) => {
+      if (!$found) {
+        if (utils.isTopInView($el, this.doc)) {
+          $found = $el;
+        }
+      }
+    });
+
+    return $found;
+  }
+
+  handlePositioning() {
     // If it's position is fixed
     if (this.$elm.classList.contains(this.cssFixedClassName)) {
 

--- a/assets/js/components/ViewSelector.js
+++ b/assets/js/components/ViewSelector.js
@@ -98,25 +98,28 @@ module.exports = class ViewSelector {
   handleHighlighting(findClosest) {
     const $firstViewableHeading = this.findFirstInView(this.collapsibleSectionHeadings,
                                                        this.doc, this.window);
-    const $section = this.findSectionForHeading($firstViewableHeading,
-                                                this.collapsibleSectionHeadings[0].innerHTML,
-                                                findClosest);
+    const firstLogicalHeadingText = this.collapsibleSectionHeadings[0] ?
+                                                  this.collapsibleSectionHeadings[0].innerHTML : '';
+    const $section = ViewSelector.findSectionForLinkHighlight($firstViewableHeading,
+                                                              firstLogicalHeadingText,
+                                                              findClosest);
 
     if ($section && typeof $section.id === 'string') {
-      const $target = this.findLinkToHighlight(this.$jumpLinksList, `[href="#${$section.id}"]`);
+      const $target = ViewSelector.findLinkToHighlight(this.$jumpLinksList, `[href="#${$section.id}"]`);
       if ($target) {
-        this.clearJumpLinkHighlight(this.jumpLinks);
-        this.highlightJumpLink($target);
+        ViewSelector.clearJumpLinkHighlight(this.jumpLinks);
+        ViewSelector.highlightJumpLink($target);
       }
     }
   }
 
-  findSectionForHeading($heading, firstHeadingText, findClosest) {
+  static findSectionForLinkHighlight($heading, firstHeadingText, findClosest) {
     if (!$heading) {
       return;
     }
 
-    // 48px chosen arbitrarily by designer when reviewing feature
+    // If the heading is near or off the top of the window, use the section for that heading,
+    // otherwise, use the section before the section for that heading
     if ($heading.innerHTML === firstHeadingText || $heading.getBoundingClientRect().top < 48) {
       return findClosest.call(null, $heading, '.article-section');
     }
@@ -124,18 +127,18 @@ module.exports = class ViewSelector {
     return findClosest.call(null, $heading, '.article-section').previousElementSibling;
   }
 
-  clearJumpLinkHighlight($jumpLinksList) {
+  static clearJumpLinkHighlight($jumpLinksList) {
     const linksList = [].slice.call($jumpLinksList);
     linksList.forEach(($link) => {
       $link.classList.remove('view-selector__jump_link--active');
     });
   }
 
-  findLinkToHighlight($linksList, selector) {
+  static findLinkToHighlight($linksList, selector) {
     return $linksList.querySelector(selector);
   }
 
-  highlightJumpLink($jumpLink) {
+  static highlightJumpLink($jumpLink) {
     $jumpLink.classList.add('view-selector__jump_link--active');
   }
 

--- a/assets/js/libs/elife-utils.js
+++ b/assets/js/libs/elife-utils.js
@@ -492,6 +492,25 @@ module.exports = () => {
     return $overlay;
   }
 
+  /**
+   *
+   * Determines if the top of an element is within the viewport bounds
+   *
+   * @param {HTMLElement} $elm
+   * @param {Document} doc
+   * @returns {boolean} true if the top of the element is within the viewport bounds
+   */
+  function isTopInView($elm, doc) {
+    const rect = $elm.getBoundingClientRect();
+    const html = doc.documentElement;
+    return (
+      rect.top >= 0 &&
+      rect.top <= (window.innerHeight || html.clientHeight) &&
+      rect.left >= 0 &&
+      rect.left <= (window.innerWidth || html.clientWidth)
+    );
+  }
+
   return {
     adjustPxString: adjustPxString,
     areElementsNested: areElementsNested,
@@ -505,6 +524,7 @@ module.exports = () => {
     defer: defer,
     flatten: flatten,
     invertPxString: invertPxString,
+    isTopInView: isTopInView,
     jumpToAnchor: jumpToAnchor,
     loadData: loadData,
     nthChild: nthChild,

--- a/assets/js/libs/elife-utils.js
+++ b/assets/js/libs/elife-utils.js
@@ -512,6 +512,38 @@ module.exports = () => {
     );
   }
 
+  /**
+   * Throttle a function to run with specified interval
+   *
+   * The function should be an arrow function to ensure scope is correct
+   * @param {Function} fn The function to throttle
+   * @param {Number} thresholdInMs The minimum interval between calls to the thottled function
+   * @returns {Function}
+   */
+  function throttle(fn, thresholdInMs = 250/*, scope*/) {
+    // threshold || (threshold = 250);
+    let last;
+    let deferTimer;
+    return function () {
+      // const context = scope || this;
+      const now = +new Date();
+      const args = arguments;
+      if (last && now < last + thresholdInMs) {
+        // hold on to it
+        window.clearTimeout(deferTimer);
+        deferTimer = window.setTimeout(function () {
+          last = now;
+          // fn.apply(context, args);
+          fn.apply(null, args);
+        }, thresholdInMs);
+      } else {
+        last = now;
+        // fn.apply(context, args);
+        fn.apply(null, args);
+      }
+    };
+  }
+
   return {
     adjustPxString: adjustPxString,
     areElementsNested: areElementsNested,
@@ -530,6 +562,7 @@ module.exports = () => {
     loadData: loadData,
     nthChild: nthChild,
     remoteDoc: remoteDoc,
+    throttle: throttle,
     uniqueIds: uniqueIds,
     updateElementTranslate: updateElementTranslate,
     wrapElements: wrapElements,

--- a/assets/js/libs/elife-utils.js
+++ b/assets/js/libs/elife-utils.js
@@ -192,7 +192,7 @@ module.exports = () => {
    *
    * @param {String} pxString The string representing the original quantity, e.g. '97px'
    * @param adjustment The numeric adjustment to make, e.g. 8
-   * @param operation
+   * @param requestedOperation
    * @returns {string} The modified value, as a string, e.g.: '105px'
    */
   function adjustPxString(pxString, adjustment, requestedOperation) {
@@ -498,16 +498,17 @@ module.exports = () => {
    *
    * @param {HTMLElement} $elm
    * @param {Document} doc
+   * @param win
    * @returns {boolean} true if the top of the element is within the viewport bounds
    */
-  function isTopInView($elm, doc) {
+  function isTopInView($elm, doc, win) {
     const rect = $elm.getBoundingClientRect();
     const html = doc.documentElement;
     return (
       rect.top >= 0 &&
-      rect.top <= (window.innerHeight || html.clientHeight) &&
+      rect.top <= (win.innerHeight || html.clientHeight) &&
       rect.left >= 0 &&
-      rect.left <= (window.innerWidth || html.clientWidth)
+      rect.left <= (win.innerWidth || html.clientWidth)
     );
   }
 

--- a/assets/js/libs/elife-utils.js
+++ b/assets/js/libs/elife-utils.js
@@ -516,29 +516,26 @@ module.exports = () => {
    * Throttle a function to run with specified interval
    *
    * The function should be an arrow function to ensure scope is correct
-   * @param {Function} fn The function to throttle
+   * @param {Function} fn The arrow function to throttle
    * @param {Number} thresholdInMs The minimum interval between calls to the thottled function
    * @returns {Function}
    */
-  function throttle(fn, thresholdInMs = 250/*, scope*/) {
-    // threshold || (threshold = 250);
+  function throttle(fn, thresholdInMs = 250) {
     let last;
     let deferTimer;
     return function () {
-      // const context = scope || this;
       const now = +new Date();
       const args = arguments;
       if (last && now < last + thresholdInMs) {
+
         // hold on to it
         window.clearTimeout(deferTimer);
         deferTimer = window.setTimeout(function () {
           last = now;
-          // fn.apply(context, args);
           fn.apply(null, args);
         }, thresholdInMs);
       } else {
         last = now;
-        // fn.apply(context, args);
         fn.apply(null, args);
       }
     };

--- a/assets/sass/patterns/molecules/view-selector.scss
+++ b/assets/sass/patterns/molecules/view-selector.scss
@@ -52,6 +52,10 @@
   color: $color-text-secondary;
 }
 
+.view-selector__jump_link--active {
+  color: $color-text;
+}
+
 .view-selector__jump_links_header {
   color: $color-text-secondary;
   display: block;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -291,7 +291,7 @@ gulp.task('server', () => {
     server = express();
     server.use(express.static('./'));
     server.listen('8080');
-    browserSync({proxy: 'localhost:8080', startPath: 'test/contentheader.html'});
+    browserSync({proxy: 'localhost:8080', startPath: 'test/viewselector.html'});
   } else {
     return gutil.noop;
   }

--- a/source/_patterns/04-pages/article--research.json
+++ b/source/_patterns/04-pages/article--research.json
@@ -1,7 +1,6 @@
 {
   "isPrimaryResearch": true,
   "hasRelated": true,
-  "viewSelector": true,
   "siteHeader": {
     "homePagePath": "#",
     "primaryLinks": {
@@ -457,16 +456,12 @@
           "url": "#introduction"
         },
         {
-          "name": "Results",
-          "url": "#results"
-        },
-        {
-          "name": "Discussion",
-          "url": "#discussion"
-        },
-        {
           "name": "Materials & methods",
           "url": "#materials-and-methods"
+        },
+        {
+          "name": "Article and author information",
+          "url": "#articleInfo"
         },
         {
           "name": "References",

--- a/source/_patterns/04-pages/article--research.mustache
+++ b/source/_patterns/04-pages/article--research.mustache
@@ -50,7 +50,7 @@
                 {{> molecules-pl-only-article-section-for-download-links}}
               {{/pl-only-article-section-for-download-links}}
 
-              <section class="article-section" data-behaviour="ArticleSection">
+              <section class="article-section" data-behaviour="ArticleSection" id="references">
                 <header class="article-section__header">
                   <h2 class="article-section__header_text">References</h2>
                 </header>

--- a/test/viewselector.spec.js
+++ b/test/viewselector.spec.js
@@ -94,7 +94,7 @@ describe('A ViewSelector Component', function () {
 
   it('has a toggleable list of jump links', function () {
     let viewSelector = new ViewSelector($elm);
-    expect(viewSelector.$jumpLinks instanceof HTMLElement).to.be.true;
+    expect(viewSelector.$jumpLinksList instanceof HTMLElement).to.be.true;
     expect(viewSelector.toggleJumpLinks).to.be.a('function');
   });
 
@@ -107,19 +107,19 @@ describe('A ViewSelector Component', function () {
     });
 
     it('expands when toggled open', function () {
-      viewSelector.$jumpLinks.classList.add('visuallyhidden');
+      viewSelector.$jumpLinksList.classList.add('visuallyhidden');
       viewSelector.$jumpLinksToggle.classList.add('view-selector__jump_links_header--closed');
       viewSelector.toggleJumpLinks();
-      expect(viewSelector.$jumpLinks.classList.contains('visuallyhidden')).to.be.false;
+      expect(viewSelector.$jumpLinksList.classList.contains('visuallyhidden')).to.be.false;
       expect(viewSelector.$jumpLinksToggle.classList
                          .contains('view-selector__jump_links_header--closed')).to.be.false;
     });
 
     it('collapses when toggled closed', function () {
-      viewSelector.$jumpLinks.classList.remove('visuallyhidden');
+      viewSelector.$jumpLinksList.classList.remove('visuallyhidden');
       viewSelector.$jumpLinksToggle.classList.remove('view-selector__jump_links_header--closed');
       viewSelector.toggleJumpLinks();
-      expect(viewSelector.$jumpLinks.classList.contains('visuallyhidden')).to.be.true;
+      expect(viewSelector.$jumpLinksList.classList.contains('visuallyhidden')).to.be.true;
       expect(viewSelector.$jumpLinksToggle.classList
                          .contains('view-selector__jump_links_header--closed')).to.be.true;
     });

--- a/test/viewselector.spec.js
+++ b/test/viewselector.spec.js
@@ -125,7 +125,7 @@ describe('A ViewSelector Component', function () {
                          .contains('view-selector__jump_links_header--closed')).to.be.true;
     });
 
-    context('with its knowledge of top level article section headings', () => {
+    context('with knowledge of top level article section headings', () => {
 
       let docFake;
       let winFake;
@@ -165,7 +165,7 @@ describe('A ViewSelector Component', function () {
         };
       };
 
-      it('can identify the first section heading in view when it is the first', () => {
+      it('can identify the first section heading in view when it is the first logical heading', () => {
         const fakeEls = [
           buildFakeElement(0, 0),
           buildFakeElement(200, 0)
@@ -173,7 +173,7 @@ describe('A ViewSelector Component', function () {
         expect(viewSelector.findFirstInView(fakeEls, docFake, winFake)).to.deep.equal(fakeEls[0]);
       });
 
-      it('can identify the first section heading in view when it is not the first', () => {
+      it('can identify the first section heading in view when it is not the first logical heading', () => {
         const fakeEls = [
           buildFakeElement(-200, 0),
           buildFakeElement(600, 0)
@@ -191,7 +191,7 @@ describe('A ViewSelector Component', function () {
 
         context('when the first viewable section heading is the first logical section heading', () => {
 
-          it('identifies the first section heading as the section to highlight the link to, regardless of its top position',
+          it('identifies the first section heading as the section to highlight the link to, regardless of the heading\'s top position',
              () => {
               const elPositions = [ { top: 0, left: 0 }, { top: 60, left: 0 } ];
               elPositions.forEach((position) => {
@@ -218,133 +218,100 @@ describe('A ViewSelector Component', function () {
 
         });
 
-        context('when the first viewable section heading is not the first logical section heading',
+        context('when the first viewable section heading is not the first logical section heading', () => {
+
+          context(
+            'and it is less than 48px lower than the top of the top of the viewport',
+            () => {
+
+              const fakeSecondHeading = {
+                el: buildFakeElement(47, 0, 'Second heading text'),
+                findClosest: function () {
+                  return {
+                    previousElementSibling: 'I am the previousElementSibling'
+                  };
+                }
+              };
+              spy(fakeSecondHeading, 'findClosest');
+
+              it(
+                'identifies that section heading\'s section as the section to highlight the link to',
                 () => {
-
-                  context(
-                    'and it is less than 48px lower than the top of the top of the viewport',
-                    () => {
-
-                      const fakeSecondHeading = {
-                        el: buildFakeElement(47, 0, 'Second heading text'),
-                        findClosest: function () {
-                          return {
-                            previousElementSibling: 'I am the previousElementSibling'
-                          };
-                        }
-                      };
-                      spy(fakeSecondHeading, 'findClosest');
-
-                      it(
-                        'identifies that section heading\'s section as the section to highlight the link to',
-                        () => {
-                          ViewSelector.findSectionForLinkHighlight(fakeSecondHeading.el, firstHeadingText,
-                                                                   fakeSecondHeading.findClosest);
-                          expect(fakeSecondHeading.findClosest.calledWithExactly(fakeSecondHeading.el,
-                                                                                '.article-section')).to.be.true;
-                          expect(fakeSecondHeading.findClosest.returned(
-                            {previousElementSibling: 'I am the previousElementSibling'})).to.be.true;
-                          fakeSecondHeading.findClosest.restore();
-                        });
-
-                    });
-
-                  context(
-                    'and it is 48px or more below the top of the viewport',
-                    () => {
-
-                      const fakeSecondHeading = {
-                        el: buildFakeElement(48, 0, 'Second heading text'),
-                        findClosest: function () {
-                          return {
-                            previousElementSibling: 'I am the previousElementSibling'
-                          };
-                        }
-                      };
-                      spy(fakeSecondHeading, 'findClosest');
-
-                      it(
-                        'identifies the section following the section heading\'s section as the section to highlight the link to',
-                        () => {
-                          ViewSelector.findSectionForLinkHighlight(fakeSecondHeading.el, firstHeadingText,
-                                                                   fakeSecondHeading.findClosest);
-                          expect(fakeSecondHeading.findClosest.calledWithExactly(fakeSecondHeading.el,
-                                                                                 '.article-section')).to.be.true;
-                          expect(fakeSecondHeading.findClosest.returned('I am the previousElementSibling')).to.be.true;
-                          fakeSecondHeading.findClosest.restore();
-
-                        });
-
-                    });
-
+                  ViewSelector.findSectionForLinkHighlight(fakeSecondHeading.el, firstHeadingText,
+                                                           fakeSecondHeading.findClosest);
+                  expect(fakeSecondHeading.findClosest.calledWithExactly(fakeSecondHeading.el,
+                                                                        '.article-section')).to.be.true;
+                  expect(fakeSecondHeading.findClosest.returned(
+                    {previousElementSibling: 'I am the previousElementSibling'})).to.be.true;
+                  fakeSecondHeading.findClosest.restore();
                 });
 
-      });
+            });
 
-    });
+          context(
+            'and it is 48px or more below the top of the viewport',
+            () => {
 
-    describe('its side-by-side link', function () {
+              const fakeSecondHeading = {
+                el: buildFakeElement(48, 0, 'Second heading text'),
+                findClosest: function () {
+                  return {
+                    previousElementSibling: 'I am the previousElementSibling'
+                  };
+                }
+              };
+              spy(fakeSecondHeading, 'findClosest');
 
-      let viewSelector;
+              it(
+                'identifies the section following the section heading\'s section as the section to highlight the link to',
+                () => {
+                  const obs = ViewSelector.findSectionForLinkHighlight(fakeSecondHeading.el, firstHeadingText,
+                                                           fakeSecondHeading.findClosest);
+                  expect(fakeSecondHeading.findClosest.calledWithExactly(fakeSecondHeading.el,
+                                                                         '.article-section')).to.be.true;
+                  expect(obs).to.equal('I am the previousElementSibling');
+                  fakeSecondHeading.findClosest.restore();
+                });
 
-      beforeEach(() => {
-        window.CSS = {
-          supports: () => true
-        };
-        viewSelector = new ViewSelector($elm);
-      });
+            });
 
-      context('when the browser can display the side by side view', () => {
-
-        it('is displayed on load', function () {
-          const link = $elm.querySelector('.view-selector__link--side-by-side');
-          expect(link).to.not.be.null;
-          expect(link.textContent).to.equal('Side by side');
-          expect(link.href).to.equal('https://lens.elifesciences.org/19749/index.html');
-        });
-
-        it('opens an iframe', function () {
-          const link = $elm.querySelector('.view-selector__link--side-by-side');
-          link.click();
-          expect(viewSelector.sideBySideView.$iframe).to.not.be.undefined;
-          expect(viewSelector.sideBySideView.$iframe.classList.contains('hidden')).to.be.false;
-        });
-
-      });
-
-      context('when the browser cannot display the side by side view', () => {
-
-        it('is not displayed if the link is not supplied', function () {
-          $elm.dataset.sideBySideLink = '';
-          expect(viewSelector.sideBySideViewAvailable()).to.be.false;
-        });
-
-        it('is not displayed if the link looks broken', function () {
-          $elm.dataset.sideBySideLink = 'localhost/null';
-          expect(viewSelector.sideBySideViewAvailable()).to.be.false;
-        });
-
-        it('is not displayed if the browser is probably Edge or IE', function () {
-          // Explicity fail the capability check used to determine whether the link is displayed
-          window.CSS.supports = (property, value) => {
-            if (property === 'text-orientation' || property === '-webkit-text-orientation') {
-              if (value === 'sideways') {
-                return false;
-              }
-            }
-            return true;
-          };
-
-          expect(new ViewSelector($elm, window).sideBySideViewAvailable()).to.be.false;
-
-          window.CSS.supports = null;
-          expect(new ViewSelector($elm, window).sideBySideViewAvailable()).to.be.false;
-
-          window.CSS = null;
-          expect(new ViewSelector($elm, window).sideBySideViewAvailable()).to.be.false;
         });
 
       });
+
+      describe('identification of the section link to highlight', () => {
+
+        let $target;
+        let $idOfTarget;
+
+        beforeEach(() => {
+          $idOfTarget = 'introduction';
+          $target = ViewSelector.findLinkToHighlight($elm, `[href="#${$idOfTarget}"]`);
+        });
+
+        it('identifies the jump link to the required section', () => {
+          expect($target.innerHTML).to.equal('Introduction');
+        });
+
+        it('highlights the jump link to the required section', () => {
+          ViewSelector.updateHighlighting($target, viewSelector.jumpLinks);
+          expect($target.classList.contains('view-selector__jump_link--active')).to.be.true;
+        });
+
+        it('clears the jump link highlight on all but the required section', () => {
+          const $notTarget = $elm.querySelector('[href="#results"]');
+          // Set the class that the OUT should remove
+          $notTarget.classList.add('view-selector__jump_link--active');
+          ViewSelector.updateHighlighting($target, viewSelector.jumpLinks);
+          expect($notTarget.classList.contains('view-selector__jump_link--active')).to.be.false;
+          [].forEach.call(viewSelector.jumpLinks, ($link) => {
+            if ($link.href !== $target.href)
+              expect($link.classList.contains('view-selector__jump_link--active')).to.be.false;
+          });
+        });
+
+      });
+
     });
 
     it('maintains a list of top level article section headings', () => {
@@ -365,5 +332,70 @@ describe('A ViewSelector Component', function () {
     });
 
   });
+
+  describe('its side-by-side link', function () {
+
+    let viewSelector;
+
+    beforeEach(() => {
+      window.CSS = {
+        supports: () => true
+      };
+      viewSelector = new ViewSelector($elm);
+    });
+
+    context('when the browser can display the side by side view', () => {
+
+      it('is displayed on load', function () {
+        const link = $elm.querySelector('.view-selector__link--side-by-side');
+        expect(link).to.not.be.null;
+        expect(link.textContent).to.equal('Side by side');
+        expect(link.href).to.equal('https://lens.elifesciences.org/19749/index.html');
+      });
+
+      it('opens an iframe', function () {
+        const link = $elm.querySelector('.view-selector__link--side-by-side');
+        link.click();
+        expect(viewSelector.sideBySideView.$iframe).to.not.be.undefined;
+        expect(viewSelector.sideBySideView.$iframe.classList.contains('hidden')).to.be.false;
+      });
+
+    });
+
+    context('when the browser cannot display the side by side view', () => {
+
+      it('is not displayed if the link is not supplied', function () {
+        $elm.dataset.sideBySideLink = '';
+        expect(viewSelector.sideBySideViewAvailable()).to.be.false;
+      });
+
+      it('is not displayed if the link looks broken', function () {
+        $elm.dataset.sideBySideLink = 'localhost/null';
+        expect(viewSelector.sideBySideViewAvailable()).to.be.false;
+      });
+
+      it('is not displayed if the browser is probably Edge or IE', function () {
+        // Explicity fail the capability check used to determine whether the link is displayed
+        window.CSS.supports = (property, value) => {
+          if (property === 'text-orientation' || property === '-webkit-text-orientation') {
+            if (value === 'sideways') {
+              return false;
+            }
+          }
+          return true;
+        };
+
+        expect(new ViewSelector($elm, window).sideBySideViewAvailable()).to.be.false;
+
+        window.CSS.supports = null;
+        expect(new ViewSelector($elm, window).sideBySideViewAvailable()).to.be.false;
+
+        window.CSS = null;
+        expect(new ViewSelector($elm, window).sideBySideViewAvailable()).to.be.false;
+      });
+
+    });
+  });
+
 
 });

--- a/test/viewselector.spec.js
+++ b/test/viewselector.spec.js
@@ -1,4 +1,5 @@
 let expect = chai.expect;
+let spy = sinon.spy;
 
 // load in component(s) to be tested
 let ViewSelector = require('../assets/js/components/ViewSelector');
@@ -33,14 +34,14 @@ describe('A ViewSelector Component', function () {
       };
       let _viewSelector1 = new ViewSelector($elm, windowMock);
       _viewSelector1.elmYOffset = 20;
-      _viewSelector1.handleScroll();
+      _viewSelector1.handleScrolling();
 
       let classes1 = _viewSelector1.$elm.classList;
       expect(classes1.contains('view-selector--fixed')).to.be.true;
 
       let _viewSelector2 = new ViewSelector($elm, windowMock);
       _viewSelector2.elmYOffset = 20;
-      _viewSelector2.handleScroll();
+      _viewSelector2.handleScrolling();
 
       let classes2 = _viewSelector2.$elm.classList;
       expect(classes2.contains('view-selector--fixed')).to.be.true;
@@ -55,7 +56,7 @@ describe('A ViewSelector Component', function () {
       };
       let _viewSelector = new ViewSelector($elm, windowMock);
       _viewSelector.elmYOffset = 20;
-      _viewSelector.handleScroll();
+      _viewSelector.handleScrolling();
 
       let classes = _viewSelector.$elm.classList;
       expect(classes.contains('view-selector--fixed')).to.be.false;
@@ -85,7 +86,7 @@ describe('A ViewSelector Component', function () {
          expect(fakeBottomOfMainEl).to.be.below(_viewSelector.$elm.offsetHeight);
 
          _viewSelector.$elm.classList.add('view-selector--fixed');
-         _viewSelector.handleScroll();
+         _viewSelector.handleScrolling();
          expect(_viewSelector.$elm.classList.contains('view-selector--fixed')).to.be.true;
          expect(_viewSelector.$elm.style.top.indexOf('px')).to.be.above(-1);
        });
@@ -124,6 +125,28 @@ describe('A ViewSelector Component', function () {
                          .contains('view-selector__jump_links_header--closed')).to.be.true;
     });
 
+    describe('a jump link', () => {
+
+      let sectionHeadings;
+      beforeEach(() => {
+        sectionHeadings = [
+
+        ];
+      });
+
+      context('when its linked section is the top-most in view', () => {
+
+        xit('is highlighted');
+
+      });
+
+      context('when its linked section is not the top-most in view', () => {
+
+        xit('is not highlighted');
+
+      });
+
+    });
 
   });
 
@@ -189,6 +212,37 @@ describe('A ViewSelector Component', function () {
       });
 
     });
+  });
+
+  it('maintains a list of top level article section headings', () => {
+    const expectedHeadingList = ['headingOne', 'headingTwo'];
+    const doc = {
+      querySelectorAll: () => {
+        return expectedHeadingList;
+      }
+    };
+    spy(doc, 'querySelectorAll');
+    const headingList = ViewSelector.getAllCollapsibleSectionHeadings(doc);
+    expect(doc.querySelectorAll.calledWithExactly('[data-behaviour="ArticleSection"] > .article-section__header .article-section__header_text')).to.be.true;
+    expect(headingList).to.have.length(2);
+    expect(headingList).to.equal(expectedHeadingList);
+    doc.querySelectorAll.restore();
+  });
+
+  describe('its knowledge of the section headings', () => {
+
+    const headingList = [
+      {
+        getBoundingClientRect: () => {
+
+        }
+      }
+    ];
+
+    it('can identify the first section heading in view', () => {
+
+    });
+
   });
 
 });

--- a/test/viewselector.spec.js
+++ b/test/viewselector.spec.js
@@ -30,6 +30,11 @@ describe('A ViewSelector Component', function () {
       let windowMock = {
         addEventListener: function () {
         },
+        matchMedia: function() {
+          return {
+            matches: true
+          }
+        },
         pageYOffset: 20
       };
       let _viewSelector1 = new ViewSelector($elm, windowMock);
@@ -52,6 +57,11 @@ describe('A ViewSelector Component', function () {
       let windowMock = {
         addEventListener: function () {
         },
+        matchMedia: function() {
+          return {
+            matches: true
+          }
+        },
         pageYOffset: 10
       };
       let _viewSelector = new ViewSelector($elm, windowMock);
@@ -69,6 +79,11 @@ describe('A ViewSelector Component', function () {
          let fakeBottomOfMainEl = 20;
          let windowMock = {
            addEventListener: function () {
+           },
+           matchMedia: function() {
+             return {
+               matches: true
+             }
            },
            pageYOffset: 30
          };


### PR DESCRIPTION
Highlights the link to the current section in an article's jump menu. Includes tests.

As well as/as part of the feature implementation, this update includes:
- 2 new utils functions:
  - `throttle` - we need it for this feature, rather than `debounce`
  - `isTopInView` - determine whether the top of an element is within the viewport
- perf improvements for resize/scroll event detection
- minor renaming improvements

