### PR TITLE
Fix <dt> margin-top

### DIFF
--- a/assets/sass/_normalize-overrides.scss
+++ b/assets/sass/_normalize-overrides.scss
@@ -138,9 +138,7 @@ dd {
 
 dt {
   font-weight: 700;
-  dd + & {
-    @include margin(24, "top");
-  }
+  @include margin(24, "top");
 }
 
 dd {

--- a/assets/sass/patterns/molecules/archive-nav-link.scss
+++ b/assets/sass/patterns/molecules/archive-nav-link.scss
@@ -8,6 +8,7 @@
 .archive-nav-link__sub_links_list_heading {
   @include label-content-typeg();
   @include padding(8 0);
+  margin-top: 0;
 }
 
 .archive-nav-link__sub_links_list_item {


### PR DESCRIPTION
#717 caused the first source data to not have a margin on top (between it and the captioned asset). There was only one case where we're not expecting it to have a top margin, so seemed easier to override there.