### PR TITLE
ELPP-2831 Increase space above meta info

### DIFF
--- a/assets/sass/_mixins.scss
+++ b/assets/sass/_mixins.scss
@@ -310,6 +310,7 @@
 }
 
 @mixin teaser-footer-style() {
+  @include margin(12, "top");
   color: $color-text-secondary;
   display: flex;
   @include label-content-typeg();

--- a/assets/sass/patterns/molecules/teaser.scss
+++ b/assets/sass/patterns/molecules/teaser.scss
@@ -87,7 +87,6 @@
 
 .teaser__secondary_info {
   @include listing-main-author-typeg();
-  @include padding(0, "bottom");
   @include margin(12, "bottom");
 }
 

--- a/assets/sass/patterns/molecules/teaser.scss
+++ b/assets/sass/patterns/molecules/teaser.scss
@@ -87,7 +87,8 @@
 
 .teaser__secondary_info {
   @include listing-main-author-typeg();
-  @include padding(12, "bottom");
+  @include padding(0, "bottom");
+  @include margin(12, "bottom");
 }
 
 .teaser__body {


### PR DESCRIPTION
We obtain this by using two margins around secondary info and footer. If the teaser body (impact statement) in between the two is missing, the two margins collapse resulting in still only 12px of distance