### PR TITLE
ELPP-3019 Separate image credit overlay from the text

### DIFF
--- a/source/_patterns/02-organisms/content-headers/content-header.mustache
+++ b/source/_patterns/02-organisms/content-headers/content-header.mustache
@@ -1,5 +1,5 @@
 {{#image}}
-<div class="content-header-image-wrapper{{^image.credit}}{{^image.creditOverlay}} content-header-image-wrapper--no-credit{{/image.creditOverlay}}{{/image.credit}}">
+<div class="content-header-image-wrapper{{^image.creditOverlay}}{{^image.credit}} content-header-image-wrapper--no-credit{{/image.credit}}{{/image.creditOverlay}}">
 {{/image}}
   <header
     class="content-header {{#image}}content-header--image content-header--header{{/image}} {{^image}}wrapper {{#header.possible}}content-header--header{{/header.possible}}{{/image}} clearfix"

--- a/source/_patterns/02-organisms/content-headers/content-header.mustache
+++ b/source/_patterns/02-organisms/content-headers/content-header.mustache
@@ -1,5 +1,5 @@
 {{#image}}
-<div class="content-header-image-wrapper{{^image.credit}} content-header-image-wrapper--no-credit{{/image.credit}}">
+<div class="content-header-image-wrapper{{^image.credit}}{{^image.creditOverlay}} content-header-image-wrapper--no-credit{{/image.creditOverlay}}{{/image.credit}}">
 {{/image}}
   <header
     class="content-header {{#image}}content-header--image content-header--header{{/image}} {{^image}}wrapper {{#header.possible}}content-header--header{{/header.possible}}{{/image}} clearfix"
@@ -159,11 +159,11 @@
     </div>
   {{/meta}}
 
+{{#image.creditOverlay}}
   {{#image.credit}}
-    {{#overlay}}
       <div class="content-header__image-credit content-header__image-credit--overlay" id="{{elementId}}">{{{text}}}</div>
-    {{/overlay}}
   {{/image.credit}}
+{{/image.creditOverlay}}
 
 </header>
 
@@ -171,11 +171,11 @@
   {{> molecules-audio-player}}
 {{/audioPlayer}}
 
-{{#image.credit}}
-  {{^overlay}}
+{{^image.creditOverlay}}
+  {{#image.credit}}
       <div class="wrapper"><div class="content-header__image-credit" id="{{elementId}}">{{{text}}}</div></div>
-  {{/overlay}}
-{{/image.credit}}
+  {{/image.credit}}
+{{/image.creditOverlay}}
 
 {{#image}}
   </div>

--- a/source/_patterns/02-organisms/content-headers/content-header.yaml
+++ b/source/_patterns/02-organisms/content-headers/content-header.yaml
@@ -28,12 +28,12 @@ schema:
                 elementId:
                   type: string
                   minLength: 1
-                overlay:
-                  type: boolean
-                  default: false
               required:
                 - text
                 - elementId
+            creditOverlay:
+              type: boolean
+              default: false
     impactStatement:
       type: string
       minLength: 1

--- a/source/_patterns/02-organisms/content-headers/content-header~background-with-audio-player.json
+++ b/source/_patterns/02-organisms/content-headers/content-header~background-with-audio-player.json
@@ -40,7 +40,8 @@
       "defaultPath": "https://iiif.elifesciences.org/journal-cms:collection/2015-09/2d2e35c4-tropical-disease-elife-collections.png/0,159,1800,543/1114,336/0/default.png",
       "srcset": "https://iiif.elifesciences.org/journal-cms:collection/2015-09/2d2e35c4-tropical-disease-elife-collections.png/0,159,1800,543/1114,336/0/default.png 1114w, https://iiif.elifesciences.org/journal-cms:collection/2015-09/2d2e35c4-tropical-disease-elife-collections.png/0,159,1800,543/2228,672/0/default.png 2228w",
       "altText": ""
-    }
+    },
+    "creditOverlay": true
   },
   "title": "Epidemiology and Global Health",
   "longTitle": true,

--- a/source/_patterns/02-organisms/content-headers/content-header~background-with-image-credit-overlay.json
+++ b/source/_patterns/02-organisms/content-headers/content-header~background-with-image-credit-overlay.json
@@ -43,9 +43,9 @@
     },
     "credit": {
       "text": "I haz image credit <a href=\"#\">with a link</a>.",
-      "elementId": "iAmTheIdOfTheImageCreditElement",
-      "overlay": true
-    }
+      "elementId": "iAmTheIdOfTheImageCreditElement"
+    },
+    "creditOverlay": true
   },
   "title": "Epidemiology and Global Health",
   "longTitle": true,

--- a/source/_patterns/04-pages/magazine.json
+++ b/source/_patterns/04-pages/magazine.json
@@ -126,9 +126,9 @@
       },
       "credit": {
         "text": "This is an image credit <a href=\"#\">with a link</a>.",
-        "elementId": "iAmTheElementIdForTheImegeCreditElement",
-        "overlay": true
-      }
+        "elementId": "iAmTheElementIdForTheImegeCreditElement"
+      },
+      "creditOverlay": true
     },
     "audioPlayer": {
       "title": "Episode 21",


### PR DESCRIPTION
On the archive month page we need to use the image credit overlay, but we might not always have the data. Without it, the space beneath appears. This separates the overlay from the text, so it can still be applied.