### PR TITLE
Stop initialising components if other patterns aren't available

### DIFF
--- a/assets/js/components/ArticleDownloadLinksList.js
+++ b/assets/js/components/ArticleDownloadLinksList.js
@@ -14,6 +14,16 @@ module.exports = class ArticleDownloadLinksList {
     this.doc = doc;
     this.$elm = $elm;
 
+    this.$contentHeader = this.doc.querySelector('.content-header');
+    if (!this.$contentHeader) {
+      return;
+    }
+
+    this.$contentHeaderDownloadLink = this.$contentHeader.querySelector('.content-header__download_link');
+    if (!this.$contentHeaderDownloadLink) {
+      return;
+    }
+
     // One statement per class name because IE doesn't support multiple strings, comma separated.
     this.$elm.classList.add('article-download-links-list--js');
     this.$elm.classList.add('visuallyhidden');
@@ -26,11 +36,9 @@ module.exports = class ArticleDownloadLinksList {
    * Moves the download links list to be by the icon this.$toggler
    */
   moveList() {
-    let $newParent = this.doc.querySelector('.content-header');
-    let $followingSibling =
-      $newParent.querySelector('.content-header__download_link').nextElementSibling;
+    let $followingSibling = this.$contentHeaderDownloadLink.nextElementSibling;
     this.$elm.parentNode.parentNode.classList.add('visuallyhidden');
-    $newParent.insertBefore(this.$elm, $followingSibling);
+    this.$contentHeader.insertBefore(this.$elm, $followingSibling);
   }
 
   /**

--- a/assets/js/components/AssetNavigation.js
+++ b/assets/js/components/AssetNavigation.js
@@ -15,6 +15,10 @@ module.exports = class AssetNavigation {
     if ($seeAll) {
       promise = utils.remoteDoc($seeAll.href, this.window).then((doc) => {
         const $newAsset = doc.querySelector(`#${this.$elm.id}`);
+        if (!$newAsset) {
+          return [this.$elm];
+        }
+
         const $newSupplements = doc.querySelectorAll(`[data-parent-asset-id="${this.$elm.id}"]`);
 
         // Avoid circular behaviour.

--- a/assets/js/components/SiteHeader.js
+++ b/assets/js/components/SiteHeader.js
@@ -26,6 +26,10 @@ module.exports = class SiteHeader {
     }
 
     const $overlayParent = this.doc.querySelector('.main');
+    if (!$overlayParent) {
+      return;
+    }
+
     const $overlayFollowingSibling = $overlayParent.firstElementChild;
     this.pageOverlay = new Overlay($overlayParent, $overlayFollowingSibling, 'mainMenuOverlay', this.window, this.doc);
     this.pageOverlay.assignTop(96);

--- a/assets/js/components/ViewSelector.js
+++ b/assets/js/components/ViewSelector.js
@@ -34,6 +34,9 @@ module.exports = class ViewSelector {
     }
 
     this.mainTarget = this.doc.querySelector('.main');
+    if (!this.mainTarget) {
+      return;
+    }
 
     // matches top padding in scss
     let topSpaceWhenFixed = 30;


### PR DESCRIPTION
Some components require others to be available on the page, but this doesn't happen inside Pattern Lab leading to JS errors.