### PR TITLE
Keep overlay when scrolling

### DIFF
--- a/assets/sass/_mixins.scss
+++ b/assets/sass/_mixins.scss
@@ -368,7 +368,7 @@
 
 @mixin overlay() {
   background-color: $color-overlay;
-  position: absolute;
+  position: fixed;
   min-height: 100vh;
   top: 0;
   width: 100vw;


### PR DESCRIPTION
Scrolling with the menu open currently sees the overlay disappear:

<img width="391" alt="screen shot 2017-10-12 at 08 21 41" src="https://user-images.githubusercontent.com/1784740/31484155-17e97d58-af27-11e7-8aac-20ded4d1cdc0.png">
