### PR TITLE
Fix p elements in author details

### DIFF
--- a/assets/sass/patterns/atoms/author-details.scss
+++ b/assets/sass/patterns/atoms/author-details.scss
@@ -1,17 +1,17 @@
 @import "../../definitions";
 
 .author-details__section {
-  @include padding(24, "bottom");
+  @include margin(24, "bottom");
 
   .popup__content & {
-    @include padding(18, "bottom");
-  }
+    @include margin(18, "bottom");
 
-  .popup__content & {
-    @include padding(18, "bottom");
+    p {
+      @include margin(18, "bottom");
+    }
 
     &:last-child {
-      padding-bottom: 0;
+      margin-bottom: 0;
     }
   }
 
@@ -57,8 +57,16 @@
   @include body-para();
   @include nospace("bottom");
 
+  p {
+    @include body-typeg();
+  }
+
   .popup__content & {
     @include popup-ancillary-text();
+
+    p {
+      @include popup-ancillary-text();
+    }
   }
 
 }


### PR DESCRIPTION
Spotted a few spacing/sizing problems where we have `<p>` elements inside author details:

<img width="662" alt="screen shot 2017-10-12 at 11 56 39" src="https://user-images.githubusercontent.com/1784740/31492820-9745ff8c-af44-11e7-90cf-acb3b8eb885b.png">

<img width="629" alt="screen shot 2017-10-12 at 11 56 54" src="https://user-images.githubusercontent.com/1784740/31492821-98959af0-af44-11e7-9ab5-1130386199f7.png">
