### PR TITLE
Use real URI in login control

### DIFF
--- a/assets/js/components/LoginControl.js
+++ b/assets/js/components/LoginControl.js
@@ -205,7 +205,7 @@ module.exports = class LoginControl {
    */
   insertToggle($container, $elm, buildElement) {
     const $toggle = buildElement.call(null, 'a', ['login-control__controls_toggle'], '', $container);
-    $toggle.setAttribute('href', '#');
+    $toggle.setAttribute('href', this.defaultUri);
     const iconAsString = $elm.dataset.icon;
     if (typeof iconAsString === 'string' && iconAsString.length) {
       $toggle.innerHTML = iconAsString;


### PR DESCRIPTION
In case someone drags the link into a new tab etc, we should use a real URI wherever possible.