### PR TITLE
Line height mixin

### DIFF
--- a/assets/sass/_mixins.scss
+++ b/assets/sass/_mixins.scss
@@ -263,6 +263,12 @@
   }
 }
 
+// $vertical-height-in-px: desired height of the element as a function of font-size and line-height
+@mixin font-size-and-vertical-height($font-size, $vertical-height-in-px: 24) {
+  @include font-size($font-size);
+  line-height: #{($vertical-height-in-px / $font-size)};
+}
+
 @mixin body-para {
   @include body-typeg();
   @include body-spacing();
@@ -441,4 +447,3 @@
     text-decoration: underline;
   }
 }
-

--- a/assets/sass/_mixins.scss
+++ b/assets/sass/_mixins.scss
@@ -377,7 +377,7 @@
 
 @mixin dismissible_navigation {
   @include typeg-portal-quick-nav();
-  @include font-size-and-vertical-height($bkpt-captioned-asset-caption, 48);
+  @include font-size-and-vertical-height($font-size-base-in-px, 48);
   @include nospace();
   text-align: center;
 }

--- a/assets/sass/_mixins.scss
+++ b/assets/sass/_mixins.scss
@@ -264,9 +264,9 @@
 }
 
 // $vertical-height-in-px: desired height of the element as a function of font-size and line-height
-@mixin font-size-and-vertical-height($font-size, $vertical-height-in-px: 24) {
-  @include font-size($font-size);
-  line-height: #{($vertical-height-in-px / $font-size)};
+@mixin font-size-and-vertical-height($font-size-in-px, $vertical-height-in-px: 24) {
+  @include font-size($font-size-in-px);
+  line-height: #{($vertical-height-in-px / $font-size-in-px)};
 }
 
 @mixin body-para {
@@ -377,7 +377,7 @@
 
 @mixin dismissible_navigation {
   @include typeg-portal-quick-nav();
-  line-height: 3;
+  @include font-size-and-vertical-height($bkpt-captioned-asset-caption, 48);
   @include nospace();
   text-align: center;
 }

--- a/assets/sass/_mixins.scss
+++ b/assets/sass/_mixins.scss
@@ -404,22 +404,19 @@
 }
 
 @mixin popup_title_text {
-  @include font-size(14);
-  line-height: 1.4285714286; /* 20px on 24px font */
+  @include font-size-and-vertical-height(14, 20);
 }
 
 @mixin popup-ancillary-text() {
   color: $color-text--reverse;
   font-family: $font-secondary;
-  @include font-size(11);
-  line-height: 1.6363636364; /* 18px on 11px font */
+  @include font-size-and-vertical-height(11, 18);
 }
 
 @mixin popup-large-ancillary-text() {
   color: $color-text--reverse;
   font-family: $font-secondary;
-  @include font-size(14);
-  line-height: #{(20/14)};
+  @include font-size-and-vertical-height(14, 20);
 }
 
 @mixin inline-image {
@@ -437,11 +434,10 @@
 @mixin non_js_control_link {
   color: $color-text;
   font-family: $font-secondary;
-  @include font-size(14);
+  @include font-size-and-vertical-height(14);
   font-weight: normal;
   text-decoration: underline;
   text-transform: none;
-  line-height: 1.7142857143; // 24px on 14px font-size
 
   &:hover {
     text-decoration: underline;

--- a/assets/sass/_typographic-hierarchy.scss
+++ b/assets/sass/_typographic-hierarchy.scss
@@ -277,7 +277,7 @@
 
 @mixin section-title-typeg() {
   font-family: $font-secondary;
-  @include font-size(14, 14);
+  @include font-size-and-vertical-height(14, 14);
   font-weight: 700;
   text-transform: uppercase;
 }

--- a/assets/sass/_typographic-hierarchy.scss
+++ b/assets/sass/_typographic-hierarchy.scss
@@ -26,7 +26,7 @@
     @if $screen-width == "extra-wide" {
       @return map-get($title-sizes-article--extra-wide-screen, $title-size);
     }
-    @return 16;
+    @return $font-size-base-in-px;
 
   } @else {
     @if $screen-width == "narrow" {
@@ -41,7 +41,7 @@
     @if $screen-width == "extra-wide" {
       @return map-get($title-sizes-non-article--extra-wide-screen, $title-size);
     }
-    @return 16;
+    @return $font-size-base-in-px;
   }
 }
 
@@ -91,7 +91,7 @@
 
 @mixin h3-typeg() {
   @include _heading-base-typeg();
-  @include font-size-and-vertical-height($font-size-h3-in-px); /* 24px when font size is 22px */
+  @include font-size-and-vertical-height($font-size-h3-in-px);
 }
 
 @mixin h3-spacing() {
@@ -164,12 +164,12 @@
 
 @mixin author-typeg() {
   font-family: $font-secondary;
-  @include font-size-and-vertical-height(16);
+  @include font-size-and-vertical-height($font-size-base-in-px);
 }
 
 @mixin subtitle-typeg() {
   font-family: $font-secondary;
-  @include font-size-and-vertical-height(16);
+  @include font-size-and-vertical-height($font-size-base-in-px);
   font-weight: 500;
 }
 
@@ -200,7 +200,7 @@
 
 @mixin fig-viewer-heading-typeg($is-wide: false) {
   font-family: $font-secondary;
-  @include _set-typeg-width-variant(16, 20, $is-wide);
+  @include _set-typeg-width-variant($font-size-base-in-px, 20, $is-wide);
   line-height: 1;
 }
 
@@ -243,7 +243,7 @@
 
 @mixin lead-para-typeg($is-wide: false) {
   font-family: $font-primary;
-  @include _set-typeg-width-variant(16, 17, $is-wide);
+  @include _set-typeg-width-variant($font-size-base-in-px, 17, $is-wide);
   font-weight: 700;
   line-height: 1.5;
   text-align: center;
@@ -272,7 +272,7 @@
   background-color: #fff;
   color: $color-text;
   font-family: $font-secondary;
-  @include font-size-and-vertical-height(16);
+  @include font-size-and-vertical-height($font-size-base-in-px);
 }
 
 @mixin section-title-typeg() {
@@ -294,7 +294,7 @@
 
 @mixin typeg-portal-quick-nav() {
   font-family: $font-secondary;
-  @include font-size-and-vertical-height(16);
+  @include font-size-and-vertical-height($font-size-base-in-px);
 }
 
 @mixin msa-link($is-wide: false) {
@@ -309,7 +309,7 @@
 
 @mixin see-more-link-typeg() {
   font-family: $font-secondary;
-  @include font-size-and-vertical-height(16);
+  @include font-size-and-vertical-height($font-size-base-in-px);
 }
 
 @mixin label-content-typeg($color:$color-text-secondary, $uppercase: true) {
@@ -364,12 +364,12 @@
 
 @mixin listing-main-author-typeg() {
   font-family: $font-secondary;
-  @include font-size-and-vertical-height(16);
+  @include font-size-and-vertical-height($font-size-base-in-px);
 }
 
 @mixin listing-main-subtitle-typeg() {
   font-family: $font-secondary;
-  @include font-size-and-vertical-height(16);
+  @include font-size-and-vertical-height($font-size-base-in-px);
   font-weight: 700;
 }
 

--- a/assets/sass/_typographic-hierarchy.scss
+++ b/assets/sass/_typographic-hierarchy.scss
@@ -58,9 +58,8 @@
 @mixin _label-typeg($uppercase: true) {
   font-family: $font-secondary;
   font-weight: normal;
-  @include font-size(11);
+  @include font-size-and-vertical-height(11);
   letter-spacing: 0.5px;
-  line-height: 2.1818181818; /* 24px with a font size of 11px */
   @if $uppercase {
     text-transform: uppercase;
   }
@@ -70,8 +69,7 @@
 
 @mixin h1-typeg($is-wide:false) {
   @include _heading-base-typeg();
-  @include font-size($font-size-h1-in-px);
-  line-height: 1.333333333; /* 48px when font size is 36px */
+  @include font-size-and-vertical-height($font-size-h1-in-px, 48);
   // Arbitrary values for now:
   @include _set-typeg-width-variant(36, 36, $is-wide);
 }
@@ -82,8 +80,7 @@
 
 @mixin h2-typeg() {
   @include _heading-base-typeg();
-  @include font-size($font-size-h2-in-px);
-  line-height: 1.1538461538; /* 30px line height with font size of 26px */
+  @include font-size-and-vertical-height($font-size-h2-in-px, 30);
 }
 
 @mixin h2-spacing() {
@@ -94,8 +91,7 @@
 
 @mixin h3-typeg() {
   @include _heading-base-typeg();
-  @include font-size($font-size-h3-in-px); /* 24px when font size is 22px */
-  line-height: 1.09090909090909;
+  @include font-size-and-vertical-height($font-size-h3-in-px); /* 24px when font size is 22px */
 }
 
 @mixin h3-spacing() {
@@ -106,8 +102,7 @@
 
 @mixin h4-typeg() {
   @include _heading-base-typeg();
-  @include font-size($font-size-h4-in-px);
-  line-height: 1.2; /* 24px when font size is 20px */
+  @include font-size-and-vertical-height($font-size-h4-in-px);
 }
 
 @mixin h4-spacing() {
@@ -118,8 +113,7 @@
 
 @mixin h5-typeg() {
   @include _heading-base-typeg();
-  @include font-size($font-size-h5-in-px);
-  line-height: 1.33333333333333; /* 24px when font size is 18px */
+  @include font-size-and-vertical-height($font-size-h5-in-px);
 }
 
 @mixin h5-spacing() {
@@ -130,8 +124,7 @@
 
 @mixin h6-typeg() {
   @include _heading-base-typeg();
-  @include font-size($font-size-h6-in-px);
-  line-height: 1.5; /* 24px when font size is 16px */
+  @include font-size-and-vertical-height($font-size-h6-in-px);
 }
 
 @mixin h6-spacing() {
@@ -150,9 +143,8 @@
 
 @mixin body-typeg() {
   font-family: $font-primary;
-  @include font-size($font-size-base-in-px);
+  @include font-size-and-vertical-height($font-size-base-in-px);
   font-weight: normal;
-  line-height: 1.5;
 }
 
 // TODO: consider where this should sit, and should other spacing be refactored out from typeg defs?
@@ -164,8 +156,7 @@
 @mixin small-typeg() {
   font-family: $font-primary;
   font-style: normal;
-  @include font-size(11);
-  line-height: 2.18181818181818; /* 24px when font size is 11px  */
+  @include font-size-and-vertical-height(11);
   @include padding(24, "bottom");
 }
 
@@ -173,37 +164,32 @@
 
 @mixin author-typeg() {
   font-family: $font-secondary;
-  @include font-size(16);
-  line-height: 1.5;
+  @include font-size-and-vertical-height(16);
 }
 
 @mixin subtitle-typeg() {
   font-family: $font-secondary;
-  @include font-size(16);
+  @include font-size-and-vertical-height(16);
   font-weight: 500;
-  line-height: 1.5;
 }
 
 @mixin institute-typeg() {
   font-family: $font-secondary;
-  @include font-size(14);
+  @include font-size-and-vertical-height(14);
   font-weight: 500;
-  line-height: 1.71428571428571;
 }
 
 @mixin pullquote-typeg() {
   font-family: $font-secondary;
-  @include font-size(24);
+  @include font-size-and-vertical-height(24, 31.2);
   font-weight: 500;
-  line-height: 1.3;
 }
 
 @mixin quote-attrib-typeg() {
   font-family: $font-primary;
-  @include font-size(14);
+  @include font-size-and-vertical-height(14, 18.2);
   font-style: italic;
   font-weight: 400;
-  line-height: 1.3;
 
   a {
     color: inherit;
@@ -221,23 +207,22 @@
 @mixin fig-heading-typeg() {
   // bold, not demibold
   font-family: $font-secondary;
-  @include font-size(14);
+  @include font-size-and-vertical-height(14);
   font-weight: bold;
-  line-height: 1.7142857143; /* 24px with 14px font size */
 }
 
 @mixin fig-caption-heading-typeg() {
   font-family: $font-secondary;
-  @include font-size($font-size-caption-in-px);
+  @include font-size-and-vertical-height($font-size-caption-in-px);
   font-weight: 700;
-  line-height: 1.8461538462; /* 24px when font size is 13px  */
 }
 
 @mixin fig-caption-text-typeg($space-underneath: 19, $set-line-height: true) {
   font-family: $font-secondary;
-  @include font-size($font-size-caption-in-px);
   @if $set-line-height == true {
-    line-height: 1.8461538462; /* 24px when font size is 13px  */
+    @include font-size-and-vertical-height($font-size-caption-in-px);
+  } @else {
+    @include font-size($font-size-caption-in-px);
   }
   @include padding($space-underneath, "bottom");
   text-decoration: none;
@@ -245,16 +230,14 @@
 
 @mixin table-head-typeg() {
   font-family: $font-secondary;
-  @include font-size(13);
+  @include font-size-and-vertical-height(13, 16.9);
   font-weight: 700;
-  line-height: 1.3;
   @include padding(3, "bottom");
 }
 
 @mixin table-cell-typeg() {
   font-family: $font-secondary;
-  @include font-size(13);
-  line-height: 1.3;
+  @include font-size-and-vertical-height(13, 16.9);
   @include padding(19, "bottom");
 }
 
@@ -270,15 +253,13 @@
 
 @mixin nav-typeg() {
   font-family: $font-secondary;
-  @include font-size(14);
+  @include font-size-and-vertical-height(14);
   font-weight: 700;
-  line-height: 1.7142857143; /* 24px with 14px font size */
 }
 
 @mixin nav-small-typeg() {
   @include nav-typeg();
-  @include font-size(11);
-  line-height: 2.1818181818;
+  @include font-size-and-vertical-height(11);
 }
 
 @mixin nav-page-typeg() {
@@ -291,8 +272,7 @@
   background-color: #fff;
   color: $color-text;
   font-family: $font-secondary;
-  @include font-size(16);
-  line-height: 1.5;
+  @include font-size-and-vertical-height(16);
 }
 
 @mixin section-title-typeg() {
@@ -305,36 +285,32 @@
 
 @mixin footer-links-typeg($is-wide: false) {
   font-family: $font-secondary;
-  @include font-size(14);
   font-weight: 700;
   @if $is-wide == false {
-    line-height: 1.85;
+    @include font-size-and-vertical-height(14, 25.9);
   } @else {
-    line-height: 2.35;
+    @include font-size-and-vertical-height(14, 32.9);
   }
 }
 
 @mixin typeg-portal-quick-nav() {
   font-family: $font-secondary;
-  @include font-size(16);
-  line-height: 1.5;
+  @include font-size-and-vertical-height(16);
 }
 
 @mixin msa-link($is-wide: false) {
   font-family: $font-secondary;
-  @include font-size(12);
   font-weight: 700;
   @if $is-wide == false {
-    line-height: 1.85;
+    @include font-size-and-vertical-height(12, 22.2);
   } @else {
-    line-height: 2.35;
+    @include font-size-and-vertical-height(12, 28.2);
   }
 }
 
 @mixin see-more-link-typeg() {
   font-family: $font-secondary;
-  @include font-size(16);
-  line-height: 1.5;  // 24px at 16px font size
+  @include font-size-and-vertical-height(16);
 }
 
 @mixin label-content-typeg($color:$color-text-secondary, $uppercase: true) {
@@ -352,16 +328,14 @@
 @mixin typeg-form-label() {
   color: $color-text;
   font-family: $font-secondary;
-  @include font-size(14);
+  @include font-size-and-vertical-height(14, 18.2);
   font-weight: 700;
-  line-height: 1.3;
 }
 
 @mixin typeg-form-message() {
   color: $color-text;
   font-family: $font-secondary;
-  @include font-size(14);
-  line-height: (19/14);
+  @include font-size-and-vertical-height(14, 19);
   text-align: left;
 }
 
@@ -370,39 +344,34 @@
 @mixin typeg-checkboxes() {
   color: $color-text;
   font-family: $font-secondary;
-  @include font-size(14);
+  @include font-size-and-vertical-height(14);
   font-weight: 700;
-  line-height: 1.7142857143; /* 24px at 14px font size */
 }
 
 // FOR ITEMS IN LISTS
 
 @mixin listing-main-art-title-typeg() {
-  @include font-size(20);
-  line-height: 1.2;  // 24px with 20px text size
+  @include font-size-and-vertical-height(20);
   @include padding(12, "top");
   @include nospace("bottom");
 }
 
 @mixin listing-side-art-title-typeg() {
   font-family: $font-secondary;
-  @include font-size(18);
+  @include font-size-and-vertical-height(18);
   font-weight: 700;
-  line-height: 1.33333333333;
   @include padding(12, "top");
 }
 
 @mixin listing-main-author-typeg() {
   font-family: $font-secondary;
-  @include font-size(16);
-  line-height: 1.5;
+  @include font-size-and-vertical-height(16);
 }
 
 @mixin listing-main-subtitle-typeg() {
   font-family: $font-secondary;
-  @include font-size(16);
+  @include font-size-and-vertical-height(16);
   font-weight: 700;
-  line-height: 1.5;
 }
 
 @mixin listing-side-author-typeg() {
@@ -417,9 +386,8 @@
 
 @mixin listing-institute-typeg() {
   font-family: $font-primary;
-  @include font-size(14);
+  @include font-size-and-vertical-height(14, 18.2);
   font-style: italic;
-  line-height: 1.3;
 }
 
 @mixin listing-impact-statement-typeg() {
@@ -429,6 +397,5 @@
 
 @mixin mono-typeg() {
   font-family: $font-monospace;
-  @include font-size(14);
-  line-height: 1.5;
+  @include font-size-and-vertical-height(14, 21);
 }

--- a/assets/sass/_typographic-hierarchy.scss
+++ b/assets/sass/_typographic-hierarchy.scss
@@ -264,8 +264,8 @@
 
 @mixin nav-page-typeg() {
   @include nav-typeg();
+  @include font-size-and-vertical-height(14, 18.2);
   font-weight: normal;
-  line-height: 1.3;
 }
 
 @mixin menu-typeg() {
@@ -277,9 +277,8 @@
 
 @mixin section-title-typeg() {
   font-family: $font-secondary;
-  @include font-size(14);
+  @include font-size(14, 14);
   font-weight: 700;
-  line-height: 1;
   text-transform: uppercase;
 }
 

--- a/assets/sass/_variables.scss
+++ b/assets/sass/_variables.scss
@@ -42,7 +42,6 @@ $font-size-h5-in-px: 18;
 $font-size-h6-in-px: 16;
 $font-size-caption-in-px: 13;
 $box-font-scaling-factor: 0.85;
-$line-height-primary: 1.3;
 
 /*
  * Baseline grid

--- a/assets/sass/patterns/atoms/buttons.scss
+++ b/assets/sass/patterns/atoms/buttons.scss
@@ -9,9 +9,8 @@
   color: $color-text--reverse;
   display: inline-block;
   font-family: $font-secondary;
-  @include font-size(14);
+  @include font-size-and-vertical-height(14, 14);
   font-weight: 500;
-  line-height: 1;
   @include padding(17 40 16);
   text-align: center;
   text-decoration: none;

--- a/assets/sass/patterns/atoms/buttons.scss
+++ b/assets/sass/patterns/atoms/buttons.scss
@@ -50,15 +50,13 @@
 }
 
 .button--small {
-  @include font-size(11);
-  line-height: 2.1818181818; /* 24px at 11px font size */
+  @include font-size-and-vertical-height(11);
   @include padding(3 12);
 }
 
 .button--extra-small {
   border-radius: 3px;
-  @include font-size(11);
-  line-height: 2.1818181818; /* 24px with 11px font size */
+  @include font-size-and-vertical-height(11);
   @include padding(0 6);
   @include height(24);
 }

--- a/assets/sass/patterns/atoms/caption-text.scss
+++ b/assets/sass/patterns/atoms/caption-text.scss
@@ -40,7 +40,7 @@
   background-color: transparent;
   border: 0;
   color: $color-primary;
-  line-height: 1;
+  @include font-size-and-vertical-height(13, 13);
   margin: 0;
   padding-left: 0;
 

--- a/assets/sass/patterns/atoms/date.scss
+++ b/assets/sass/patterns/atoms/date.scss
@@ -23,8 +23,7 @@
   width: 70px;
 
   .date__prominent {
-    @include font-size(36);
-    line-height: 1;
+    @include font-size-and-vertical-height(36, 36);
     text-align: center;
     @include padding(10, "top");
   }

--- a/assets/sass/patterns/atoms/info-bars.scss
+++ b/assets/sass/patterns/atoms/info-bars.scss
@@ -19,7 +19,7 @@
   background-repeat: no-repeat;
   display: inline-block;
   @include padding(2 0 0 28);
-  line-height: 1.3;
+  @include font-size-and-vertical-height(14, 18.2);
 }
 
 .info-bar--info {

--- a/assets/sass/patterns/atoms/list-heading.scss
+++ b/assets/sass/patterns/atoms/list-heading.scss
@@ -4,7 +4,7 @@
   @include section-title-typeg();
   @include nospace();
   letter-spacing: 0.5px;
-  line-height: 1.7142857143; // 24px with a 14px font size
+  @include font-size-and-vertical-height(14);
   margin-bottom: 0;
   text-transform: uppercase;
 }

--- a/assets/sass/patterns/atoms/message-bar.scss
+++ b/assets/sass/patterns/atoms/message-bar.scss
@@ -4,8 +4,7 @@
   background-color: $color-text-ui-code;
   border: 1px solid $color-text-dividers;
   border-radius: #{$border-radius}px;
-  @include font-size(14);
-  line-height: 1.7142857143; // 24px with 14px line height
+  @include font-size-and-vertical-height(14);
   @include padding($blg-space-extra-small-in-px);
   @include padding($blg-space-extra-small-in-px - 1, "top");
   @include padding($blg-space-extra-small-in-px - 1, "bottom");

--- a/assets/sass/patterns/atoms/reference.scss
+++ b/assets/sass/patterns/atoms/reference.scss
@@ -3,7 +3,7 @@
 .reference__title {
   @include listing-side-art-title-typeg();
   display: block;
-  @include font-size-and-vertical-height(16);
+  @include font-size-and-vertical-height($font-size-base-in-px);
   @include nospace();
   text-decoration: none;
 

--- a/assets/sass/patterns/atoms/reference.scss
+++ b/assets/sass/patterns/atoms/reference.scss
@@ -3,8 +3,7 @@
 .reference__title {
   @include listing-side-art-title-typeg();
   display: block;
-  @include font-size(16);
-  line-height: 1.5;
+  @include font-size-and-vertical-height(16);
   @include nospace();
   text-decoration: none;
 
@@ -26,8 +25,7 @@ a.reference__title:hover {
 
 .reference__author {
   @include listing-side-author-typeg();
-  @include font-size(14);
-  line-height: 1.714285714; /* 24px with 14px font size */
+  @include font-size-and-vertical-height(14);
   display: inline;
   margin: 0;
   padding: 0;
@@ -68,8 +66,7 @@ a.reference__authors_link:hover {
 
 .reference__origin {
   @include small-typeg();
-  @include font-size(14);
-  line-height: 1.7142857143;
+  @include font-size-and-vertical-height(14);
   padding-bottom: 0;
 
   & a {
@@ -90,8 +87,7 @@ a.reference__authors_link:hover {
 .reference__abstract {
   display: inline;
   @include small-typeg();
-  @include font-size(14);
-  line-height: 1.7142857143;
+  @include font-size-and-vertical-height(14);
 
   .popup__content & {
     @include popup-ancillary-text();

--- a/assets/sass/patterns/atoms/section-listing-link.scss
+++ b/assets/sass/patterns/atoms/section-listing-link.scss
@@ -5,8 +5,7 @@
   color: $color-text;
   display: block;
   font-family: $font-secondary;
-  @include font-size($font-size-base-in-px);
-  line-height: 1.5;
+  @include font-size-and-vertical-height($font-size-base-in-px);
   @include padding($blg-space-extra-small-in-px - 1 0 $blg-space-extra-small-in-px);
   text-align: center;
   text-decoration: none;

--- a/assets/sass/patterns/atoms/table.scss
+++ b/assets/sass/patterns/atoms/table.scss
@@ -42,18 +42,16 @@ th {
   background-color: $color-text-ui-code;
   border: 1px solid $color-text-dividers;
   font-family: $font-secondary;
-  @include font-size(13);
+  @include font-size-and-vertical-height(13, 18);
   font-weight: 700;
-  line-height: 1.3846153846; /* 18px with 13px font size */
   @include padding(6);
 }
 
 td {
   border: 1px solid $color-text-dividers;
   font-family: $font-secondary;
-  @include font-size(13);
+  @include font-size-and-vertical-height(13, 18);
   font-weight: 500;
-  line-height: 1.3846153846; /* 18px with 13px font size */
   @include padding(6);
 }
 

--- a/assets/sass/patterns/atoms/text-fields.scss
+++ b/assets/sass/patterns/atoms/text-fields.scss
@@ -14,7 +14,7 @@
   color: $color-text;
   display: block;
   font-family: $font-secondary;
-  @include font-size(16);
+  @include font-size($font-size-base-in-px);
   @include padding(12);
   @include margin(6, "bottom");
   width: 100%;

--- a/assets/sass/patterns/atoms/triggers.scss
+++ b/assets/sass/patterns/atoms/triggers.scss
@@ -1,7 +1,9 @@
+@import "../../definitions";
+
 .trigger {
   background-color: white;
+  @include font-size-and-vertical-height($font-size-base-in-px, 48);
   height: 48px;
-  line-height: 48px;
   margin: 10px;
   position: absolute;
   text-align: center;

--- a/assets/sass/patterns/molecules/about-profile.scss
+++ b/assets/sass/patterns/molecules/about-profile.scss
@@ -1,8 +1,7 @@
 @import "../../definitions";
 
 .about-profile__name {
-  @include font-size(18);
-  line-height: (24 / 18);
+  @include font-size-and-vertical-height(18);
   @include nospace();
   @include padding(12, "top");
 

--- a/assets/sass/patterns/molecules/audio-player.scss
+++ b/assets/sass/patterns/molecules/audio-player.scss
@@ -36,7 +36,7 @@
 .audio-player__header {
   color: $color-text--reverse;
   @include listing-side-art-title-typeg();
-  @include font-size-and-vertical-height(16);
+  @include font-size-and-vertical-height($font-size-base-in-px);
   @include nospace();
 }
 

--- a/assets/sass/patterns/molecules/audio-player.scss
+++ b/assets/sass/patterns/molecules/audio-player.scss
@@ -36,8 +36,7 @@
 .audio-player__header {
   color: $color-text--reverse;
   @include listing-side-art-title-typeg();
-  @include font-size(16);
-  line-height: 1.5;
+  @include font-size-and-vertical-height(16);
   @include nospace();
 }
 

--- a/assets/sass/patterns/molecules/carousel-item.scss
+++ b/assets/sass/patterns/molecules/carousel-item.scss
@@ -76,8 +76,7 @@
 }
 
 .carousel-item__title {
-  @include font-size(24);
-  line-height: 30/24;
+  @include font-size-and-vertical-height(24, 30);
   @include padding(0);
   @include padding(12, "bottom");
 }
@@ -192,19 +191,16 @@
   }
 
   .carousel-item__title {
-    @include font-size(36);
-    line-height: 48/36;
+    @include font-size-and-vertical-height(36, 48);
     @include margin(0, "top");
     @include margin(0, "bottom");
 
     @media only all and (min-width: #{get-rem-from-px($bkpt-content-header--medium-width)}em) {
-      @include font-size(41);
-      line-height: 48/41;
+      @include font-size-and-vertical-height(41, 48);
     }
 
     @media only all and (min-width: #{get-rem-from-px($bkpt-content-header--wide)}em) {
-      @include font-size(46);
-      line-height: 72/46;
+      @include font-size-and-vertical-height(46, 72);
     }
   }
 

--- a/assets/sass/patterns/molecules/carousel-item.scss
+++ b/assets/sass/patterns/molecules/carousel-item.scss
@@ -49,7 +49,7 @@
 .carousel-item__subject_list_item {
   @include label-subject-typeg();
   display: inline;
-  line-height: 2.18181818181818;
+  @include font-size-and-vertical-height(11);
   list-style-type: none;
   padding: 0;
 

--- a/assets/sass/patterns/molecules/compact-form.scss
+++ b/assets/sass/patterns/molecules/compact-form.scss
@@ -19,8 +19,7 @@
   border-radius: #{$border-radius}px;
   display: block;
   font-family: $font-secondary;
-  font-size: 1rem;
-  line-height: 1.5; /* 24px with font size of 16px */
+  @include font-size-and-vertical-height($font-size-base-in-px);
   @include padding(11 55 11 12);
   width: 100%;
 

--- a/assets/sass/patterns/molecules/filter-group.scss
+++ b/assets/sass/patterns/molecules/filter-group.scss
@@ -18,8 +18,7 @@
 }
 
 .filter-group__filter_item {
-  @include font-size($font-size-base-in-px);
-  line-height: 1.5;
+  @include font-size-and-vertical-height($font-size-base-in-px);
   @include padding($blg-space-extra-small-in-px / 2, "top");
   @include padding($blg-space-extra-small-in-px / 2, "bottom");
 }
@@ -31,6 +30,5 @@
 .filter-group__results {
   color: $color-text-secondary;
   font-family: $font-secondary;
-  @include font-size(14);
-  line-height: 1.7142857143; /* 24px on 14px font size */
+  @include font-size-and-vertical-height(14);
 }

--- a/assets/sass/patterns/molecules/highlights.scss
+++ b/assets/sass/patterns/molecules/highlights.scss
@@ -24,7 +24,7 @@
     background-color: transparent;
     border: none;
     box-sizing: content-box;
-    line-height: 1.4;
+    @include font-size-and-vertical-height(16, 22.4);
     position: absolute;
     text-align: center;
     // heading block height + (box height- icon height) / 2

--- a/assets/sass/patterns/molecules/highlights.scss
+++ b/assets/sass/patterns/molecules/highlights.scss
@@ -24,7 +24,7 @@
     background-color: transparent;
     border: none;
     box-sizing: content-box;
-    @include font-size-and-vertical-height(16, 22.4);
+    @include font-size-and-vertical-height($font-size-base-in-px, 22.4);
     position: absolute;
     text-align: center;
     // heading block height + (box height- icon height) / 2

--- a/assets/sass/patterns/molecules/login-control.scss
+++ b/assets/sass/patterns/molecules/login-control.scss
@@ -64,7 +64,7 @@ $menu-max-width-in-px: 200;
   overflow: hidden;
   white-space: nowrap;
   @include constrain-width($menu-max-width-in-px, "max");
-  @include font-size-and-vertical-height(16);
+  @include font-size-and-vertical-height($font-size-base-in-px);
 
   & + .login-control__subsidiary_text {
     @include font-size-and-vertical-height(14);

--- a/assets/sass/patterns/molecules/login-control.scss
+++ b/assets/sass/patterns/molecules/login-control.scss
@@ -33,8 +33,7 @@ $menu-max-width-in-px: 200;
 
 .login-control__control {
   font-family: $font-secondary;
-  @include font-size(14);
-  line-height: 2.6; // 36px on 14px base font size
+  @include font-size-and-vertical-height(14, 36);
   margin: 0;
   @include padding(12 18 0);
 
@@ -65,10 +64,9 @@ $menu-max-width-in-px: 200;
   overflow: hidden;
   white-space: nowrap;
   @include constrain-width($menu-max-width-in-px, "max");
-  @include font-size(16);
-  line-height: 1.5;
+  @include font-size-and-vertical-height(16);
 
   & + .login-control__subsidiary_text {
-    line-height: 1.7142857143; // 24 px on 14px font size
+    @include font-size-and-vertical-height(14);
   }
 }

--- a/assets/sass/patterns/molecules/profile-snippet.scss
+++ b/assets/sass/patterns/molecules/profile-snippet.scss
@@ -45,7 +45,7 @@
 
 .profile-snippet__title {
   font-family: $font-primary;
-  @include font-size-and-vertical-height(16);
+  @include font-size-and-vertical-height($font-size-base-in-px);
   font-weight: 400;
   margin: 0;
 }

--- a/assets/sass/patterns/molecules/profile-snippet.scss
+++ b/assets/sass/patterns/molecules/profile-snippet.scss
@@ -39,25 +39,22 @@
 
 .profile-snippet__name {
   font-family: $font-secondary;
-  @include font-size(18);
+  @include font-size-and-vertical-height(18);
   font-weight: bold;
-  line-height: 1.3333333333;  // 24px at 18px font size
 }
 
 .profile-snippet__title {
   font-family: $font-primary;
-  @include font-size(16);
+  @include font-size-and-vertical-height(16);
   font-weight: 400;
-  line-height: 1.5; // 24px at 16px font size
   margin: 0;
 }
 
 .profile-snippet__contact_details {
   font-family: $font-primary;
-  @include font-size(14);
+  @include font-size-and-vertical-height(14, 18.2);
   font-style: italic;
   font-weight: 400;
-  line-height: $line-height-primary;
   @include padding(40, "bottom");
 }
 

--- a/assets/sass/patterns/molecules/pull-quote.scss
+++ b/assets/sass/patterns/molecules/pull-quote.scss
@@ -9,7 +9,7 @@
 
   p {
     @include pullquote-typeg();
-    line-height: 1.2;
+    @include font-size-and-vertical-height(24, 28.8);
     margin: 0;
     padding: 0;
   }

--- a/assets/sass/patterns/molecules/reference-list.scss
+++ b/assets/sass/patterns/molecules/reference-list.scss
@@ -15,8 +15,7 @@
 
 .reference-list__ordinal_number {
   @include listing-side-art-title-typeg();
-  @include font-size(16);
-  line-height: 1.5;
+  @include font-size-and-vertical-height(16);
   @include padding(0);
   left: 0;
   position: absolute;

--- a/assets/sass/patterns/molecules/reference-list.scss
+++ b/assets/sass/patterns/molecules/reference-list.scss
@@ -9,13 +9,13 @@
 .reference-list__item {
   @include margin(12, "bottom");
   @include padding(0 0 0 48);
-  line-height: 1;
+  @include font-size-and-vertical-height($font-size-base-in-px, $font-size-base-in-px);
   position: relative;
 }
 
 .reference-list__ordinal_number {
   @include listing-side-art-title-typeg();
-  @include font-size-and-vertical-height(16);
+  @include font-size-and-vertical-height($font-size-base-in-px);
   @include padding(0);
   left: 0;
   position: absolute;

--- a/assets/sass/patterns/molecules/search-box.scss
+++ b/assets/sass/patterns/molecules/search-box.scss
@@ -98,8 +98,7 @@
 
 .search-box__search_option {
   font-family: $font-secondary;
-  @include font-size(14);
-  line-height: 1.7142857143; /* 24px on 14px font */
+  @include font-size-and-vertical-height(14);
   @include blg-spacing("top", "extra-small");
   @include blg-spacing("bottom", "extra-small");
 }

--- a/assets/sass/patterns/molecules/section-listing.scss
+++ b/assets/sass/patterns/molecules/section-listing.scss
@@ -51,7 +51,7 @@
     }
 
     .section-listing__list_item {
-      line-height: 1.5;
+      @include font-size-and-vertical-height($font-size-base-in-px);
       text-align: left;
     }
 

--- a/assets/sass/patterns/molecules/sort-control.scss
+++ b/assets/sass/patterns/molecules/sort-control.scss
@@ -4,9 +4,8 @@
   @include blg-spacing("top", "extra-small");
   @include blg-spacing("bottom", "extra-small");
   font-family: $font-secondary;
-  @include font-size(16);
+  @include font-size-and-vertical-height(16);
   font-weight: 700;
-  line-height: (24 / 16);
 }
 
 .sort-control__title {

--- a/assets/sass/patterns/molecules/sort-control.scss
+++ b/assets/sass/patterns/molecules/sort-control.scss
@@ -4,7 +4,7 @@
   @include blg-spacing("top", "extra-small");
   @include blg-spacing("bottom", "extra-small");
   font-family: $font-secondary;
-  @include font-size-and-vertical-height(16);
+  @include font-size-and-vertical-height($font-size-base-in-px);
   font-weight: 700;
 }
 

--- a/assets/sass/patterns/molecules/statistic.scss
+++ b/assets/sass/patterns/molecules/statistic.scss
@@ -13,7 +13,6 @@
 }
 
 .statistic__value {
-  line-height: 1;
   margin: 0;
   text-align: center;
   text-transform: uppercase;

--- a/assets/sass/patterns/molecules/teaser.scss
+++ b/assets/sass/patterns/molecules/teaser.scss
@@ -20,8 +20,7 @@
 .teaser__context_label_list_item {
 
   @include teaser-context-label-list-item-style();
-  @include font-size(11);
-  line-height: 2.1818181818;
+  @include font-size-and-vertical-height(11);
   & .teaser__context_label:after {
     content: ", ";
   }
@@ -41,8 +40,7 @@
 
 // Extra specificity to override normalised style
 .teaser .teaser__context_label_link {
-  @include font-size(11);
-  line-height: 2.1818181818;  // 24px at 11px font size
+  @include font-size-and-vertical-height(11);
   text-decoration: none;
 
   .teaser__context_label {

--- a/assets/sass/patterns/molecules/view-selector.scss
+++ b/assets/sass/patterns/molecules/view-selector.scss
@@ -165,7 +165,7 @@
   }
 
   .view-selector__link {
-    line-height: 2.5714285714; /* 36px at 14px font size */
+    @include font-size-and-vertical-height(14, 36);
     @include height(34);
     @include nospace();
     text-align: center;

--- a/assets/sass/patterns/molecules/view-selector.scss
+++ b/assets/sass/patterns/molecules/view-selector.scss
@@ -2,8 +2,7 @@
 
 @mixin local-item-style {
   font-family: $font-secondary;
-  @include font-size(14);
-  line-height: 1.7142857143; /* 24px with font size of 14px */
+  @include font-size-and-vertical-height(14);
   @include margin(0 0 12 0);
 }
 

--- a/assets/sass/patterns/organisms/content-header-profile.scss
+++ b/assets/sass/patterns/organisms/content-header-profile.scss
@@ -12,15 +12,13 @@
 }
 
 .content-header-profile__display_name {
-  @include font-size(20);
+  @include font-size-and-vertical-height(20, 48);
   font-weight: 700;
-  line-height: 2.4; /* 48px with font-size 20px */
   @include nospace();
 }
 
 .content-header-profile__details {
-  @include font-size(16);
-  line-height: 1.5;
+  @include font-size-and-vertical-height(16);
 }
 
 .content-header-profile__affiliations {

--- a/assets/sass/patterns/organisms/content-header-profile.scss
+++ b/assets/sass/patterns/organisms/content-header-profile.scss
@@ -18,7 +18,7 @@
 }
 
 .content-header-profile__details {
-  @include font-size-and-vertical-height(16);
+  @include font-size-and-vertical-height($font-size-base-in-px);
 }
 
 .content-header-profile__affiliations {

--- a/assets/sass/patterns/organisms/content-header-simple.scss
+++ b/assets/sass/patterns/organisms/content-header-simple.scss
@@ -11,8 +11,7 @@
 .content-header-simple__title {
   @include h2-typeg();
   color: $color-text;
-  @include font-size(20);
-  line-height: 1.2; /* 24px with font-size 20px */
+  @include font-size-and-vertical-height(20);
   @include nospace();
 }
 

--- a/assets/sass/patterns/organisms/content-header.scss
+++ b/assets/sass/patterns/organisms/content-header.scss
@@ -287,7 +287,7 @@
 .content-header__subject_list_item {
   @include label-subject-typeg();
   display: inline;
-  line-height: 2.18181818181818;
+  @include font-size-and-vertical-height(11);
   list-style-type: none;
   padding: 0;
 

--- a/assets/sass/patterns/organisms/content-header.scss
+++ b/assets/sass/patterns/organisms/content-header.scss
@@ -82,28 +82,23 @@
 }
 
 .content-header__title {
-  @include font-size(36);
-  line-height: 1.3333333333;
+  @include font-size-and-vertical-height(36, 48);
   @include margin(0, "top");
   @include margin(24, "bottom");
 
   @media only all and (min-width: #{get-rem-from-px($bkpt-site--medium)}em) {
-    @include font-size(41);
-    line-height: 1.1707317073; /* 48px with 41px font size */
+    @include font-size-and-vertical-height(41, 48);
   }
 
   @media only all and (min-width: #{get-rem-from-px($bkpt-site--wide)}em) {
-    @include font-size(46);
-    line-height: 1.5652173913;
+    @include font-size-and-vertical-height(46, 72);
   }
 
   .content-header--header &,
   .content-header--read-more & {
-    @include font-size(29);
-    line-height: 1.2413793103;
+    @include font-size-and-vertical-height(29, 36);
     @media only all and (min-width: #{get-rem-from-px($bkpt-site--medium)}em) {
-      @include font-size(36);
-      line-height: 1.3333333333;
+      @include font-size-and-vertical-height(36, 48);
     }
   }
 }
@@ -125,17 +120,15 @@
   }
 
   .content-header__title {
-    @include font-size(41);
+    @include font-size-and-vertical-height(41, 48);
     margin-bottom: 0;
-    line-height: 1.1707317073;
 
     @media only all and (min-width: #{get-rem-from-px($bkpt-site--medium)}em) {
       @include font-size(52);
     }
 
     @media only all and (min-width: #{get-rem-from-px($bkpt-site--wide)}em) {
-      @include font-size(58);
-      line-height: 1.2413793103; /* 72px with 58px font size */
+      @include font-size-and-vertical-height(58, 72);
     }
   }
 
@@ -246,8 +239,7 @@
       .content-header__profile_data {
         color: $color-text--reverse;
         font-family: $font-secondary;
-        @include font-size(14);
-        line-height: 1.7142857143; /* 24px with 14px font size */
+        @include font-size-and-vertical-height(14);
       }
     }
   }
@@ -641,8 +633,7 @@ li.content-header__institution_list_item--last .content-header__institution:afte
 .content-header__image-credit {
   color: $color-text-secondary;
   font-family: $font-secondary;
-  @include font-size(11);
-  line-height: 2.1818181818; /* 24px at 11px font size */
+  @include font-size-and-vertical-height(11);
   @include blg-spacing("top", "extra-small");
   @include blg-spacing("bottom", "extra-small");
   text-align: right;

--- a/assets/sass/patterns/organisms/email-cta.scss
+++ b/assets/sass/patterns/organisms/email-cta.scss
@@ -15,8 +15,7 @@
 .email-cta__header_text {
   @include h2-typeg();
   color: $color-text;
-  @include font-size(20);
-  line-height: 1.2; /* 24px with font-size 20px */
+  @include font-size-and-vertical-height(20);
   @include nospace();
 }
 

--- a/assets/sass/patterns/organisms/filter-panel.scss
+++ b/assets/sass/patterns/organisms/filter-panel.scss
@@ -4,9 +4,8 @@
   color: $color-text;
   display: block;
   font-family: $font-secondary;
-  @include font-size(14);
+  @include font-size-and-vertical-height(14);
   font-weight: bold;
-  line-height: 1.7142857143; /* 24px with 14px font size */
   @include blg-spacing("top", "extra-small");
   @include blg-spacing("bottom", "extra-small");
 }

--- a/assets/sass/patterns/organisms/listing.scss
+++ b/assets/sass/patterns/organisms/listing.scss
@@ -22,7 +22,7 @@ $totalHighlightsSpacing: 6;
 }
 
 .listing-list__item {
-  line-height: 1;
+  @include font-size-and-vertical-height($font-size-base-in-px, $font-size-base-in-px);
 }
 
 .listing-list--read-more {

--- a/assets/sass/patterns/organisms/side-by-side-view.scss
+++ b/assets/sass/patterns/organisms/side-by-side-view.scss
@@ -19,7 +19,7 @@
   background-color: #f7f7f7;
   width: 100%;
   height: 40px;
-  line-height: 38px;
+  @include font-size-and-vertical-height($font-size-base-in-px, 38);
 }
 
 .side-by-side-view__button-close {


### PR DESCRIPTION
This introduces the new mixin `font-size-and-vertical-height` that is to be used from now on to set all the line heights within the style blocks. It should also be used within mixins unless that doesn't make sense.

This means that every time a line height is set, the font size must now be specified too. This will help prevent bugs which can occur when the line height may be set independently of the font size, and the font size is computed by the browser is different from that which the developer expected.

Also, all uses of the bare number 16 for font sizing have been replaced by the sass variable `$font-size-base-in-px`.