### PR TITLE
Fix captioned-asset__picture

### DIFF
--- a/assets/sass/patterns/molecules/captioned-asset.scss
+++ b/assets/sass/patterns/molecules/captioned-asset.scss
@@ -25,6 +25,7 @@
 
 .captioned-asset__picture {
   display: block;
+  width: 100%;
 }
 
 .captioned-asset__image {

--- a/source/_patterns/01-molecules/components/captioned-asset.mustache
+++ b/source/_patterns/01-molecules/components/captioned-asset.mustache
@@ -4,7 +4,7 @@
     {{#open}}
     <a href="{{uri}}" class="captioned-asset__link" target="_blank" rel="noopener noreferrer">
     {{/open}}
-    <picture>
+    <picture class="captioned-asset__picture">
       {{#sources}}
         <source srcset="{{srcset}}"
             {{#type}}type="{{type}}"{{/type}}


### PR DESCRIPTION
A picture having a source with a width that's less than 100% will cause it to be that size, whereas we want it to stretch to 100%.