### PR TITLE
Fix contextual data padding and border

### DIFF
--- a/assets/sass/patterns/molecules/contextual-data.scss
+++ b/assets/sass/patterns/molecules/contextual-data.scss
@@ -1,7 +1,6 @@
 @import "../../definitions";
 
 .contextual-data {
-  border-bottom: 1px solid $color-text-dividers;
   @include label-content-typeg($color-text-secondary, false);
 }
 
@@ -27,6 +26,7 @@
 }
 
 .contextual-data__cite_wrapper {
+  border-bottom: 1px solid $color-text-dividers;
   @include blg-spacing("top", "extra-small");
   @include padding($blg-space-extra-small-in-px - 1, "bottom");
   padding-left: 0;
@@ -40,6 +40,7 @@
 
 @media only screen and (min-width: #{get-rem-from-px($bkpt-site--wide)}rem) {
   .contextual-data {
+    border-bottom: 1px solid $color-text-dividers;
     display: flex;
   }
 
@@ -47,7 +48,6 @@
     align-self: center;
     border-bottom: none;
     display: inline-block;
-    padding: 0;
     text-align: left;
   }
 
@@ -56,6 +56,7 @@
   }
 
   .contextual-data__cite_wrapper {
+    border-bottom: none;
     float: right;
     margin-left: auto;
     @include padding(11 0);

--- a/source/_patterns/01-molecules/components/contextual-data.json
+++ b/source/_patterns/01-molecules/components/contextual-data.json
@@ -4,15 +4,15 @@
     "data": [
       {
         "name": "views",
-        "value": 149
+        "value": "149"
       },
       {
         "name": "cited",
-        "value": 5
+        "value": "5"
       },
       {
         "name": "comments",
-        "value": 12,
+        "value": "12",
         "elementId": "someDocumentLevelUniqueId"
       }
     ]

--- a/source/_patterns/01-molecules/components/contextual-data.yaml
+++ b/source/_patterns/01-molecules/components/contextual-data.yaml
@@ -5,43 +5,39 @@ assets:
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object
-  anyOf:
-    -
+  properties:
+    metricsData:
+      type: object
       properties:
-        metricsData:
-          type: object
-          properties:
-            data:
-              type: array
-              minItems: 1
-              items:
-                type: object
-                properties:
-                  name:
-                    type: string
-                    minLength: 1
-                  value:
-                    type: string
-                    minLength: 1
-                  elementId:
-                    type: string
-                    minLength: 1
-                required:
-                  - name
-                  - value
-      minProperties: 1
-    -
-      properties:
-        citation:
-          type: object
-          properties:
-            citeAs:
-              type: string
-              minLength: 1
-            doi:
-              $ref: ../../00-atoms/components/doi.yaml#/schema
-          required:
-            - citeAs
-            - doi
+        data:
+          type: array
+          minItems: 1
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+                minLength: 1
+              value:
+                type: string
+                minLength: 1
+              elementId:
+                type: string
+                minLength: 1
+            required:
+              - name
+              - value
       required:
-        - citation
+        - data
+    citation:
+      type: object
+      properties:
+        citeAs:
+          type: string
+          minLength: 1
+        doi:
+          $ref: ../../00-atoms/components/doi.yaml#/schema
+      required:
+        - citeAs
+        - doi
+  minProperties: 1

--- a/source/_patterns/01-molecules/components/contextual-data~with-citation.json
+++ b/source/_patterns/01-molecules/components/contextual-data~with-citation.json
@@ -16,6 +16,15 @@
         "elementId": "someDocumentLevelUniqueId"
       }
     ]
+  },
+
+  "citation": {
+    "citeAs": "eLife 2016;5:e16370",
+    "doi": {
+      "class": "contextual-data__doi",
+      "doi": "10.7554/eLife.16370",
+      "isTruncated": true
+    }
   }
 
 }

--- a/source/_patterns/01-molecules/components/contextual-data~with-citation.json
+++ b/source/_patterns/01-molecules/components/contextual-data~with-citation.json
@@ -4,15 +4,15 @@
     "data": [
       {
         "name": "views",
-        "value": 149
+        "value": "149"
       },
       {
         "name": "cited",
-        "value": 5
+        "value": "5"
       },
       {
         "name": "comments",
-        "value": 12,
+        "value": "12",
         "elementId": "someDocumentLevelUniqueId"
       }
     ]


### PR DESCRIPTION
No padding on larger screens:

<img width="1144" alt="screen shot 2017-11-27 at 13 29 19" src="https://user-images.githubusercontent.com/1784740/33269214-d454fbd8-d377-11e7-9eb1-1d87a60ec5aa.png">

And double border on smaller:

<img width="601" alt="screen shot 2017-11-27 at 13 29 27" src="https://user-images.githubusercontent.com/1784740/33269215-d5c17596-d377-11e7-9a97-e4686ddeda77.png">

(Caused by no citation section.)