### PR TITLE
Use getElementById() where possible

### DIFF
--- a/assets/js/components/ArticleSection.js
+++ b/assets/js/components/ArticleSection.js
@@ -93,7 +93,7 @@ module.exports = class ArticleSection {
 
     try {
       if (e.detail.search(/https?:\/\//) !== 0) {
-        const $descendentEl = this.doc.querySelector('#' + e.detail);
+        const $descendentEl = this.doc.getElementById(e.detail);
         if (!!$descendentEl) {
           $descendentEl.scrollIntoView();
         }

--- a/assets/js/components/AssetNavigation.js
+++ b/assets/js/components/AssetNavigation.js
@@ -14,7 +14,7 @@ module.exports = class AssetNavigation {
     const $seeAll = this.$elm.querySelector('.asset-viewer-inline__header_link');
     if ($seeAll) {
       promise = utils.remoteDoc($seeAll.href, this.window).then((doc) => {
-        const $newAsset = doc.querySelector(`#${this.$elm.id}`);
+        const $newAsset = doc.querySelector(`#${this.$elm.id}`); // No getElementById() as this might be a remote doc.
         if (!$newAsset) {
           return [this.$elm];
         }

--- a/assets/js/components/FragmentHandler.js
+++ b/assets/js/components/FragmentHandler.js
@@ -84,7 +84,7 @@ module.exports = class FragmentHandler {
 
     let idOfCollapsedSection = this.getIdOfCollapsedSection(hash, this.doc);
     if (!!idOfCollapsedSection) {
-      this.doc.querySelector('#' + idOfCollapsedSection).dispatchEvent(utils.eventCreator('expandsection', hash));
+      this.doc.getElementById(idOfCollapsedSection).dispatchEvent(utils.eventCreator('expandsection', hash));
     }
   }
 };

--- a/assets/js/components/MediaChapterListingItem.js
+++ b/assets/js/components/MediaChapterListingItem.js
@@ -27,7 +27,7 @@ module.exports = class MediaChapterListingItem {
   }
 
   listenForChapterChange (e) {
-    let $player = this.document.querySelector('#' + e.detail);
+    let $player = this.document.getElementById(e.detail);
     if (!!$player) {
       $player.addEventListener('chapterChanged', this.indicateChapterChanged.bind(this));
     }

--- a/assets/js/components/Pager.js
+++ b/assets/js/components/Pager.js
@@ -209,7 +209,7 @@ module.exports = class Pager {
   }
 
   find$targetEl() {
-    return this.doc.querySelector('#' + this.$elm.dataset.targetid);
+    return this.doc.getElementById(this.$elm.dataset.targetid);
   }
 
 };

--- a/assets/js/components/SiteHeader.js
+++ b/assets/js/components/SiteHeader.js
@@ -35,7 +35,7 @@ module.exports = class SiteHeader {
     this.pageOverlay.assignTop(96);
 
     // N.B. $mainMenu is not part of this component's HTML hierarchy.
-    var mainMenu = doc.querySelector('#mainMenu');
+    var mainMenu = doc.getElementById('mainMenu');
     if (!!mainMenu) {
       let MainMenu = require('./MainMenu');
       this.mainMenu = new MainMenu(mainMenu);

--- a/assets/js/components/ViewSelector.js
+++ b/assets/js/components/ViewSelector.js
@@ -20,7 +20,7 @@ module.exports = class ViewSelector {
     this.cssFixedClassName = 'view-selector--fixed';
 
     if (this.sideBySideViewAvailable()) {
-      const $header = this.doc.querySelector('#siteHeader');
+      const $header = this.doc.getElementById('siteHeader');
       this.$global = this.doc.querySelector('.global-inner');
       this.sideBySideView = new SideBySideView(
         this.$global,

--- a/assets/js/libs/elife-utils.js
+++ b/assets/js/libs/elife-utils.js
@@ -100,9 +100,9 @@ module.exports = () => {
 
         // Optional check to see if id is unique in the DOM.
         if (!!document) {
-          if (!!document.querySelector &&
-              typeof document.querySelector === 'function' &&
-              document.querySelector('#' + candidate)) {
+          if (!!document.getElementById &&
+              typeof document.getElementById === 'function' &&
+              document.getElementById(candidate)) {
             return false;
           }
         }
@@ -302,7 +302,7 @@ module.exports = () => {
       return true;
     }
 
-    const $fragWithId = doc.querySelector('#' + id);
+    const $fragWithId = doc.getElementById(id);
     return areElementsNested($section, $fragWithId);
   }
 
@@ -539,7 +539,7 @@ module.exports = () => {
 
   function create$pageOverlay($parent, $followingSibling, id) {
     // element already exists
-    if (document.querySelector(`#${id}`)) {
+    if (document.getElementById(id)) {
       return;
     }
 

--- a/test/elife-utils.spec.js
+++ b/test/elife-utils.spec.js
@@ -469,8 +469,8 @@ describe('The utils library', function () {
       it('returns false if a component-unique value already exists in the document', function () {
         let idInDoc = 'alreadyInTheDoc';
         let docMock = {
-          querySelector: function (selector) {
-            return selector === '#' + idInDoc;
+          getElementById: function (id) {
+            return id === idInDoc;
           }
         };
         uIds.used = [];
@@ -486,7 +486,7 @@ describe('The utils library', function () {
       it('returns true for a value that is unique in both the component and the supplied document',
          function () {
            let docMock = {
-             querySelector: function () {
+             getElementById: function () {
                return null;
              }
            };

--- a/test/fragmenthandler.spec.js
+++ b/test/fragmenthandler.spec.js
@@ -44,11 +44,7 @@ describe('A FragmentHandler Component', function () {
               return [];
             }
           },
-          querySelector: function (selector) {
-            if (selector.indexOf('#') > -1) {
-              return true;
-            }
-          }
+          getElementById: function () {}
         };
 
         expect(fragmentHandler.getIdOfCollapsedSection('arbitraryElementId',
@@ -66,7 +62,7 @@ describe('A FragmentHandler Component', function () {
               return collapsedSectionIds
             }
           },
-          querySelector: function () {}
+          getElementById: function () {}
         };
 
         expect(fragmentHandler.getIdOfCollapsedSection(hash,
@@ -83,7 +79,7 @@ describe('A FragmentHandler Component', function () {
               return [ { id: matchingId } ];
             }
           },
-          querySelector: function () {}
+          getElementById: function () {}
         };
 
         let areElementsNestedMock = function () { return false; };
@@ -94,10 +90,31 @@ describe('A FragmentHandler Component', function () {
       it('returns the id of the collapsed section if the hash matches a descendant element',
       function () {
         let sectionId = 'iAmACollapsedSection';
+        let sectionMock = Object.create(Node.prototype);
+        sectionMock.id = sectionId;
         let descendantId = 'iAmADescendantOfACollapsedSection';
-        const doc = document.createElement('div');
-        doc.innerHTML = `<div id="${sectionId}" class="article-section--collapsed"><div id="${descendantId}"/></div>`;
-        let valueUnderTest = fragmentHandler.getIdOfCollapsedSection(descendantId, doc);
+        let descendantMock = Object.create(Node.prototype);
+        descendantMock.id = descendantId;
+        sectionMock.compareDocumentPosition = function(other) {
+          if (other.id === descendantId) {
+            return Node.DOCUMENT_POSITION_CONTAINED_BY;
+          }
+
+          return Node.DOCUMENT_POSITION_DISCONNECTED;
+        };
+        let docMock = {
+          querySelectorAll: function (selector) {
+            if (selector === '.article-section--collapsed') {
+              return [sectionMock]
+            }
+          },
+          getElementById: function (id) {
+            if(id === descendantId) {
+              return descendantMock;
+            }
+          }
+        };
+        let valueUnderTest = fragmentHandler.getIdOfCollapsedSection(descendantId, docMock);
         expect(valueUnderTest).to.equal(sectionId);
 
       });


### PR DESCRIPTION
Hypothesis can share URIs like https://elifesciences.org/articles/22901#annotations:Rpp6JttuEeeXnRsvD_86eQ. The colon character needs to be escaped if using `querySelector`, otherwise there's a `Failed to execute 'querySelector' on 'Document': '#annotations:Rpp6JttuEeeXnRsvD_86eQ' is not a valid selector` exception.

This changes it to use `getElementById()` where possible. I haven't added escaping in the remaining cases as they (should) be under our control.