### PR TITLE
Stop audio player failing to initialise on fast media load

### DIFF
--- a/assets/js/components/AudioPlayer.js
+++ b/assets/js/components/AudioPlayer.js
@@ -42,9 +42,15 @@ module.exports = class AudioPlayer {
     this.$elm.classList.add('audio-player--js');
 
     this.$playButton.classList.add('loading');
+
+    this.isPlayerReady = false;
     this.$audioElement.addEventListener('loadedmetadata', () => {
       this.playerReady(this);
     });
+
+    if (this.$audioElement.readyState >= 2) {
+      this.playerReady(this);
+    }
 
     this.usingMetadata = false;  // set to true in loadMetadata if no errors thrown
     this.loadMetadata(this.$elm.dataset.episodeNumber);
@@ -52,6 +58,11 @@ module.exports = class AudioPlayer {
   }
 
   playerReady(player) {
+    if (this.isPlayerReady) {
+      return;
+    }
+
+    this.isPlayerReady = true;
     player.duration = player.$audioElement.duration;
     player.$duration.innerHTML = AudioPlayer.secondsToMinutes(player.duration);
     player.$playButton.addEventListener('click', () => {

--- a/source/_patterns/01-molecules/components/audio-player.json
+++ b/source/_patterns/01-molecules/components/audio-player.json
@@ -1,9 +1,9 @@
 {
-  "episodeNumber": 21,
-  "title": "Episode 21",
+  "episodeNumber": 43,
+  "title": "Episode 43",
   "url": "#",
   "sources":[
-    { "src": "https://nakeddiscovery.com/scripts/mp3s/audio/ads/eLife_Podcast_06.15.mp3",
+    { "src": "https://nakeddiscovery.com/download/audio/eLife_Podcast_11.17.mp3",
       "mediaType": {
         "forMachine": "audio/mp3",
         "forHuman": "mp3"
@@ -14,5 +14,5 @@
       }
     }
   ],
-  "metadata": "{'number': 21, 'chapters': [{'number': 1, 'title': 'What causes tinnitus?', 'time': 36},{'number': 2, 'title': 'How salamanders avoid senescence', 'time': 386}, {'number': 3, 'title': 'Mouse ultrasound', 'time': 700}, {'number': 4, 'title': 'Drosophila duet: mating flies harmonise', 'time': 1010 }, { 'number': 5, 'title': 'Chemical Harpoons: bacterial anchors', 'time': 1307 } ] }"
+  "metadata": "{'number': 43, 'chapters': [{'number': 1, 'title': 'What causes tinnitus?', 'time': 36},{'number': 2, 'title': 'How salamanders avoid senescence', 'time': 386}, {'number': 3, 'title': 'Mouse ultrasound', 'time': 700}, {'number': 4, 'title': 'Drosophila duet: mating flies harmonise', 'time': 1010 }, { 'number': 5, 'title': 'Chemical Harpoons: bacterial anchors', 'time': 1307 } ] }"
 }

--- a/source/_patterns/04-pages/podcast.json
+++ b/source/_patterns/04-pages/podcast.json
@@ -140,7 +140,7 @@
        "url": "#",
        "text": "Podcast"
      },
-     "download": "https://nakeddiscovery.com/scripts/mp3s/audio/ads/eLife_Podcast_06.15.mp3",
+     "download": "https://nakeddiscovery.com/download/audio/eLife_Podcast_11.17.mp3",
      "image": {
        "fallback": {
          "defaultPath": "https://unsplash.it/1114/336"
@@ -150,7 +150,7 @@
        "title": "Episode 21",
        "episodeNumber": 21,
        "sources":[
-         { "src": "https://nakeddiscovery.com/scripts/mp3s/audio/ads/eLife_Podcast_06.15.mp3",
+         { "src": "https://nakeddiscovery.com/download/audio/eLife_Podcast_11.17.mp3",
            "mediaType": {
              "forMachine": "audio/mp3",
              "forHuman": "mp3"

--- a/test-selenium/podcast.spec.js
+++ b/test-selenium/podcast.spec.js
@@ -11,7 +11,7 @@ describe('A Podcast page', function() {
     expect(currentTime).to.equal('0:00');
     browser.waitUntil(function () {
       var duration = browser.getText('.audio-player__duration');
-      return duration === '28:05';
+      return duration === '30:23';
     }, 5000, 'expected duration to load after 5s');
   });
 


### PR DESCRIPTION
Sometimes the metadata had loaded before the event listener was registered.