### PR TITLE
Fix toggleable captions where paragraphs have a class

### DIFF
--- a/assets/js/components/ToggleableCaption.js
+++ b/assets/js/components/ToggleableCaption.js
@@ -46,7 +46,7 @@ module.exports = class ToggleableCaption {
     fullChildren.push(seeLessButton);
 
     let truncatedChildren = fullChildren;
-    if ('P' === this.$caption.firstElementChild.nodeName.toUpperCase()) {
+    if (this.$caption.firstElementChild.nodeName.toUpperCase() === 'P') {
       let truncatedChild = truncatedChildren[0];
       try {
         truncatedChild = clipper(truncatedChildren[0], 200, {

--- a/assets/js/components/ToggleableCaption.js
+++ b/assets/js/components/ToggleableCaption.js
@@ -46,8 +46,7 @@ module.exports = class ToggleableCaption {
     fullChildren.push(seeLessButton);
 
     let truncatedChildren = fullChildren;
-
-    if (truncatedChildren[0].indexOf('<p>') === 0) {
+    if ('P' === this.$caption.firstElementChild.nodeName.toUpperCase()) {
       let truncatedChild = truncatedChildren[0];
       try {
         truncatedChild = clipper(truncatedChildren[0], 200, {

--- a/source/_patterns/02-organisms/asset-viewer/asset-viewer-inline~table--nojs.json
+++ b/source/_patterns/02-organisms/asset-viewer/asset-viewer-inline~table--nojs.json
@@ -6,7 +6,7 @@
   "captionedAsset": {
     "captionText": {
       "heading": "Many features are conserved between the mammalian nephron and planarian protonephridia.",
-      "text": "<p>(A) Image of a young adult C. elegans and schematic depicting the twelve pairs of sensory neurons in the anterior amphid individuals carrying a virus with k deleterious mutations at its endemic equilibrium. class carrying the fewest number of deleterious mutations is defined as mutation class k = 0. Inset: variation in the basic reproductive rate of infected individuals (gray histogram) and variation in the net reproductive rate R of infected individuals (brown histogram) resulting from variation in the number of deleterious mutations carried by circulating viruses.</p>"
+      "text": "<p class=\"paragraph\">(A) Image of a young adult C. elegans and schematic depicting the twelve pairs of sensory neurons in the anterior amphid individuals carrying a virus with k deleterious mutations at its endemic equilibrium. class carrying the fewest number of deleterious mutations is defined as mutation class k = 0. Inset: variation in the basic reproductive rate of infected individuals (gray histogram) and variation in the net reproductive rate R of infected individuals (brown histogram) resulting from variation in the number of deleterious mutations carried by circulating viruses.</p>"
     },
 
     "table": {

--- a/test/toggleablecaption.html
+++ b/test/toggleablecaption.html
@@ -25,14 +25,16 @@
 
   <div class="caption-text__body">
 
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. In interdum, metus quis sodales pharetra, odio justo
+    <p class="paragraph">Lorem ipsum dolor sit amet, consectetur adipiscing elit. In interdum, metus quis sodales pharetra, odio justo
       blandit mi, at porta augue felis sit amet metus. Aliquam porta, justo dapibus vulputate aliquet, arcu quam tempor
       metus, et aliquam nisi nunc in est. Cras vitae leo pretium, tincidunt nisi ac, varius neque. Donec nec posuere
-      sem. Integer felis risus, sagittis et pulvinar pretium, rutrum sit amet odio. Proin erat purus, sodales a gravida
+      sem. END1</p>
+
+    <p class="paragraph">Integer felis risus, sagittis et pulvinar pretium, rutrum sit amet odio. Proin erat purus, sodales a gravida
       vitae, malesuada non sem. Integer semper enim ante. Donec odio ipsum, ultrices vel quam at, condimentum eleifend
       augue. Pellentesque id ipsum nec dui dictum commodo. Donec quis sagittis ex, sit amet tempus nisi. Nulla eu tortor
       vitae felis porta faucibus in eu leo. Donec ultrices vehicula enim, quis maximus nulla rhoncus sed. Vestibulum
-      elementum ligula quis mi aliquet, tincidunt finibus mi hendrerit.</p>
+      elementum ligula quis mi aliquet, tincidunt finibus mi hendrerit. END2</p>
 
   </div>
 

--- a/test/toggleablecaption.spec.js
+++ b/test/toggleablecaption.spec.js
@@ -15,12 +15,17 @@ describe('A ToggleableCaption Component', function () {
   });
 
   it('truncates the caption', function () {
+    expect(toggleableCaption.$caption.querySelectorAll('p')).to.have.lengthOf(1);
+    expect(toggleableCaption.$caption.querySelector('p:nth-child(1)').innerText).to.not.contains('END1');
     expect(toggleableCaption.$caption.querySelector('.caption-text__toggle--see-more')).to.exist;
     expect(toggleableCaption.$caption.querySelector('.caption-text__toggle--see-less')).to.not.exist;
   });
 
   it('collapses the caption', function () {
     toggleableCaption.toggleCaption();
+    expect(toggleableCaption.$caption.querySelectorAll('p')).to.have.lengthOf(2);
+    expect(toggleableCaption.$caption.querySelector('p:nth-child(1)').innerText).to.contains('END1');
+    expect(toggleableCaption.$caption.querySelector('p:nth-child(2)').innerText).to.contains('END2');
     expect(toggleableCaption.$caption.querySelector('.caption-text__toggle--see-more')).to.not.exist;
     expect(toggleableCaption.$caption.querySelector('.caption-text__toggle--see-less')).to.exist;
   });


### PR DESCRIPTION
#799 means that paragraphs in a toggleable caption now have a class, which broke the rather naive first-child check.