### PR TITLE
ELPP-3373 Expand article sections for annotations

### DIFF
--- a/assets/js/components/FragmentHandler.js
+++ b/assets/js/components/FragmentHandler.js
@@ -15,20 +15,8 @@ module.exports = class FragmentHandler {
     this.window = _window;
     this.doc = doc;
     this.isSingleton = true;
-    this.window.addEventListener('readystatechange', this.onReadyStateChange.bind(this));
-    this.onReadyStateChange({});
-  }
 
-  onReadyStateChange(e) {
-    if (document.readyState !== 'loading') {
-      this.initialise(e);
-      this.window.removeEventListener('readystatechange', this.onReadyStateChange.bind(this));
-    }
-  }
-
-  initialise(e) {
-    this.handleSectionOpeningViaHash(e);
-    this.window.addEventListener('hashchange', this.handleSectionOpeningViaHash.bind(this));
+    this.window.addEventListener('load', this.handleSectionOpeningViaHash.bind(this));
   }
 
   /**

--- a/assets/js/components/FragmentHandler.js
+++ b/assets/js/components/FragmentHandler.js
@@ -86,5 +86,12 @@ module.exports = class FragmentHandler {
     if (!!idOfCollapsedSection) {
       this.doc.getElementById(idOfCollapsedSection).dispatchEvent(utils.eventCreator('expandsection', hash));
     }
+
+    if (hash.indexOf('annotations:') === 0) {
+      const sections = [].slice.call(this.doc.querySelectorAll('.article-section--js'));
+      sections.forEach(($section) => {
+        $section.dispatchEvent(utils.eventCreator('expandsection'));
+      });
+    }
   }
 };

--- a/assets/js/components/HypothesisOpener.js
+++ b/assets/js/components/HypothesisOpener.js
@@ -34,6 +34,25 @@ module.exports = class HypothesisOpener {
       this.hookUpDataProvider(this.$elm, '[data-visible-annotation-count]');
     }
 
+    this.setupSectionExpansion();
+
+  }
+
+  setupSectionExpansion() {
+    this.$elm.addEventListener('click', this.expandAllArticleSections.bind(this));
+    const $prevEl = this.$elm.previousElementSibling;
+
+    // Ugh. Refactor this away when the right pattern construction for opening h client becomes apparent
+    if ($prevEl.classList.contains('contextual-data__item__hypothesis_opener')) {
+      $prevEl.addEventListener('click', this.expandAllArticleSections.bind(this));
+    }
+  }
+
+  expandAllArticleSections() {
+    const sections = [].slice.call(this.doc.querySelectorAll('.article-section--js'));
+    sections.forEach(($section) => {
+      $section.dispatchEvent(utils.eventCreator('expandsection'));
+    });
   }
 
   static applyStyleInitial($elm) {

--- a/assets/sass/patterns/molecules/contextual-data.scss
+++ b/assets/sass/patterns/molecules/contextual-data.scss
@@ -17,12 +17,17 @@
   margin: 0;
   @include padding(0 5 0 0);
 
+  &[data-hypothesis-trigger] {
+    cursor: pointer;
+  }
+
   a {
     color: inherit;
     &:hover {
       color: $color-primary;
     }
   }
+
 }
 
 .contextual-data__item__hypothesis_opener {


### PR DESCRIPTION
- expand all article sections if the URL hash begins with `annotations:`
- expand all article sections if either article hypothesis triggers are pressed.
- (make the whole hypothesis trigger element in contextual data have the pointer cursor on hover)