### PR TITLE
Hypothesis opener fixes

### DIFF
--- a/assets/js/components/HypothesisOpener.js
+++ b/assets/js/components/HypothesisOpener.js
@@ -14,17 +14,15 @@ module.exports = class HypothesisOpener {
     this.doc = doc;
 
     HypothesisOpener.applyStyleInitial(this.$elm);
+    this.$elm.classList.add('hypothesis-opener');
     this.$elm.dataset.hypothesisTrigger = '';
     this.speechBubble = new SpeechBubble(this.findElementWithClass('speech-bubble'));
     this.isContextualData = utils.areElementsNested(this.doc.querySelector('.contextual-data'), this.$elm);
-    this.$elm.classList.add('hypothesis-opener');
 
     if (!this.isContextualData) {
-
       HypothesisOpener.applyStyleArticleBody(this.$elm);
       this.setInitialDomLocation(this.$elm);
       this.$ancestorSection = utils.closest(this.$elm, '.article-section');
-
     }
 
     this.hookUpDataProvider(this.$elm, '[data-visible-annotation-count]');

--- a/assets/js/components/HypothesisOpener.js
+++ b/assets/js/components/HypothesisOpener.js
@@ -27,10 +27,7 @@ module.exports = class HypothesisOpener {
 
     }
 
-    if (this.$ancestorSection || this.isContextualData) {
-      this.hookUpDataProvider(this.$elm, '[data-visible-annotation-count]');
-    }
-
+    this.hookUpDataProvider(this.$elm, '[data-visible-annotation-count]');
     this.setupSectionExpansion();
 
   }

--- a/assets/js/components/HypothesisOpener.js
+++ b/assets/js/components/HypothesisOpener.js
@@ -28,22 +28,34 @@ module.exports = class HypothesisOpener {
     }
 
     this.hookUpDataProvider(this.$elm, '[data-visible-annotation-count]');
-    this.setupSectionExpansion();
+
+    this.containingArticleTogglableSections = this.doc.querySelectorAll('.article-section--js');
+    this.setupSectionExpansion(this.containingArticleTogglableSections);
 
   }
 
-  setupSectionExpansion() {
-    this.$elm.addEventListener('click', this.expandAllArticleSections.bind(this));
-    const $prevEl = this.$elm.previousElementSibling;
+  setupSectionExpansion(sections) {
+    if (!(sections instanceof NodeList)) {
+      return;
+    }
 
-    // Ugh. Refactor this away when the right pattern construction for opening h client becomes apparent
-    if ($prevEl.classList.contains('contextual-data__item__hypothesis_opener')) {
-      $prevEl.addEventListener('click', this.expandAllArticleSections.bind(this));
+    this.$elm.addEventListener('click', () => {
+      this.expandAllArticleSections([].slice.call(sections));
+    });
+
+    if (this.isContextualData) {
+      const $prevEl = this.$elm.previousElementSibling;
+
+      // Ugh. Refactor this away when the right pattern construction for opening h client becomes apparent
+      if (!!$prevEl && $prevEl.classList.contains('contextual-data__item__hypothesis_opener')) {
+        $prevEl.addEventListener('click', () => {
+          this.expandAllArticleSections([].slice.call(sections));
+        });
+      }
     }
   }
 
-  expandAllArticleSections() {
-    const sections = [].slice.call(this.doc.querySelectorAll('.article-section--js'));
+  expandAllArticleSections(sections) {
     sections.forEach(($section) => {
       $section.dispatchEvent(utils.eventCreator('expandsection'));
     });

--- a/assets/js/components/HypothesisOpener.js
+++ b/assets/js/components/HypothesisOpener.js
@@ -25,9 +25,6 @@ module.exports = class HypothesisOpener {
       this.setInitialDomLocation(this.$elm);
       this.$ancestorSection = utils.closest(this.$elm, '.article-section');
 
-      if (this.$ancestorSection && utils.isCollapsibleArticleSection(this.$ancestorSection)) {
-        this.setupSectionHandlers($elm, this.$ancestorSection, this.window);
-      }
     }
 
     if (this.$ancestorSection || this.isContextualData) {
@@ -140,19 +137,6 @@ module.exports = class HypothesisOpener {
     }
   }
 
-  setupSectionHandlers($elm, $section, window) {
-    this.lastKnownDisplayMode = HypothesisOpener.getCurrentDisplayMode(window);
-
-    $section.addEventListener('collapsesection', () => {
-      this.updateDomLocation($elm);
-    });
-    $section.addEventListener('expandsection', () => {
-      this.updateDomLocation($elm);
-    });
-
-    window.addEventListener('resize', utils.debounce(() => this.handleResize(), 50));
-  }
-
   static findInitialAnchorPoint($snippet) {
     const $abstract = $snippet.querySelector('#abstract');
     if ($abstract) {
@@ -164,39 +148,6 @@ module.exports = class HypothesisOpener {
            $snippet.querySelector('.article-section:last-child ol:last-child') ||
            $snippet.querySelector('.article-section ~ p:last-child') ||
            $snippet.querySelector('.article-section ~ ol:last-child');
-  }
-
-  updateDomLocation($elm) {
-
-    if (HypothesisOpener.getCurrentDisplayMode(this.window) === 'multiColumn') {
-
-      if (utils.isCollapsedArticleSection(this.$ancestorSection)) {
-        this.$ancestorSection.appendChild($elm);
-      } else {
-        this.$ancestorSection.querySelector('.article-section__body').appendChild($elm);
-      }
-
-    } else {
-      this.setInitialDomLocation($elm, this.doc);
-    }
-
-  }
-
-  static getCurrentDisplayMode(window) {
-    if (utils.isMultiColumnDisplay(window)) {
-      return 'multiColumn';
-    }
-
-    return 'singleColumn';
-  }
-
-  handleResize() {
-    const currentDisplayMode = HypothesisOpener.getCurrentDisplayMode(this.window);
-    if (currentDisplayMode !== this.lastKnownDisplayMode) {
-      this.updateDomLocation(this.$elm);
-      this.lastKnownDisplayMode = currentDisplayMode;
-    }
-
   }
 
 };

--- a/test/hypothesisopener.spec.js
+++ b/test/hypothesisopener.spec.js
@@ -7,65 +7,9 @@ describe('A HypothesisOpener Component', function () {
   'use strict';
 
   let $opener;
-  let affordance;
 
   beforeEach(() => {
     $opener = document.querySelector('[data-behaviour="HypothesisOpener"]');
-  });
-
-  describe('the getCurrentDisplayMode() method', () => {
-
-    context('when the window is at least 900px wide', () => {
-
-      let windowMock;
-
-      before(() => {
-        windowMock = {};
-        windowMock.appendChild = () => {};
-        windowMock.matchMedia = function (mediaStatement) {
-          if (mediaStatement === '(min-width: 900px)') {
-            return {
-              matches: true
-            };
-          }
-
-          return {
-            matches: false
-          };
-        }
-      });
-
-      it('returns "multiColumn"', () => {
-        expect(HypothesisOpener.getCurrentDisplayMode(windowMock)).to.equal('multiColumn');
-      });
-
-    });
-
-    context('when the window is narrower than 900px', () => {
-
-      let windowMock;
-
-      before(() => {
-        windowMock = {};
-        windowMock.matchMedia = function (mediaStatement) {
-          if (mediaStatement === '(min-width: 900px)') {
-            return {
-              matches: false
-            };
-          }
-
-          return {
-            matches: true
-          };
-        }
-      });
-
-      it('returns "singleColumn"', () => {
-        expect(HypothesisOpener.getCurrentDisplayMode(windowMock)).to.equal('singleColumn');
-      });
-
-    });
-
   });
 
   describe('the static findInitialAnchorPoint() method', () => {


### PR DESCRIPTION
- Removes the repositioning in the DOM of the article-body's hypothesis opener, which was determined based on whether the containing section was expanded or collapsed.
- Removes check that would spuriously prevent the data handler from registering outside of collapsible sections (i.e. on non-reserach content).
- Tightens up expanding all sections on hypothesis trigger click.