### PR TITLE
ELPP-3219 Make Button Collection a proper pattern

### DIFF
--- a/assets/js/components/Carousel.js
+++ b/assets/js/components/Carousel.js
@@ -55,7 +55,7 @@ module.exports = class Carousel {
   updateButtonAppearance () {
     let buttons = this.$elm.querySelectorAll('.carousel-item__cta .button');
     [].forEach.call(buttons, (button) => {
-      button.classList.add('button--outline');
+      button.classList.add('button--reversed');
     });
 
   }

--- a/assets/js/components/Metrics.js
+++ b/assets/js/components/Metrics.js
@@ -132,7 +132,7 @@ class Metrics {
   }
 
   groupingButton($grouping, label) {
-    const item = utils.buildElement(
+    const $item = utils.buildElement(
       'li',
       [
         'button-collection__item',
@@ -148,7 +148,7 @@ class Metrics {
         'button--small',
       ],
       label,
-      item
+      $item
     );
     button.href = '#';
     return button;
@@ -159,9 +159,9 @@ class Metrics {
       e.preventDefault();
 
       // Change button style.
-      const current = this.$el.querySelector('.button--default');
-      current.classList.add('button--outline');
-      current.classList.remove('button--default');
+      const $current = this.$el.querySelector('.button--default');
+      $current.classList.add('button--outline');
+      $current.classList.remove('button--default');
 
       e.currentTarget.classList.add('button--default');
       e.currentTarget.classList.remove('button--outline');

--- a/assets/js/components/Metrics.js
+++ b/assets/js/components/Metrics.js
@@ -24,7 +24,12 @@ class Metrics {
     this.$next = this.trigger('prev', 'Left', p); // "->" arrow
     this.$prev = this.trigger('next', 'Right', p); // "<-" arrow
 
-    const $grouping = utils.buildElement('ol', ['button-collection', 'button-collection--centered', 'button-collection--compact'], '', this.$el);
+    const $grouping = utils.buildElement(
+      'ol',
+      ['button-collection', 'button-collection--centered', 'button-collection--compact'],
+      '',
+      this.$el
+    );
     this.$dailyButton = this.groupingButton($grouping, 'Daily');
     this.$monthlyButton = this.groupingButton($grouping, 'Monthly');
 
@@ -67,11 +72,11 @@ class Metrics {
 
     // Name each chart in format like "downloads-by-day"
     const availableMetrics = utils.flatten(
-        this.availableCharts.map(
-            chart => this.availablePeriods.map(
-                period => `${chart}-by-${period}`
-            )
+      this.availableCharts.map(
+        chart => this.availablePeriods.map(
+          period => `${chart}-by-${period}`
         )
+      )
     );
 
     this.loadMore = this.loadMore.bind(this);
@@ -164,8 +169,8 @@ class Metrics {
 
       // Change metric and reload.
       return this.changeMetric(
-          this.selected,
-          period
+        this.selected,
+        period
       ).then(() => {
         this.renderView(this.$el, this.getSelectedMetric());
       });
@@ -203,8 +208,8 @@ class Metrics {
 
     this.currentChart = this.currentChart + 1;
     this.changeMetric(
-        this.availableCharts[this.currentChart],
-        this.period
+      this.availableCharts[this.currentChart],
+      this.period
     ).then(() => {
       this.renderView(this.$el, this.getSelectedMetric());
     });
@@ -217,8 +222,8 @@ class Metrics {
 
     this.currentChart = this.currentChart - 1;
     this.changeMetric(
-        this.availableCharts[this.currentChart],
-        this.period
+      this.availableCharts[this.currentChart],
+      this.period
     ).then(() => {
       this.renderView(this.$el, this.getSelectedMetric());
     });
@@ -284,15 +289,15 @@ class Metrics {
 
   getJsonPage(page, perView) {
     return utils.loadData(
-        this.getEndpoint(
-            this.endpoint,
-            this.type,
-            this.id,
-            this.selected,
-            this.period,
-            perView,
-            page
-        )
+      this.getEndpoint(
+        this.endpoint,
+        this.type,
+        this.id,
+        this.selected,
+        this.period,
+        perView,
+        page
+      )
     );
   }
 
@@ -325,9 +330,9 @@ class Metrics {
 
   periodToTimestamp(entry) {
     return Date.UTC(
-        parseInt(entry.year, 10),
-        parseInt(entry.month - 1, 10),
-        parseInt(entry.day ? entry.day : 1, 10)
+      parseInt(entry.year, 10),
+      parseInt(entry.month - 1, 10),
+      parseInt(entry.day ? entry.day : 1, 10)
     );
   }
 
@@ -366,15 +371,15 @@ class Metrics {
   filterMonthPeriod(firstMonth, firstMonthYear, viewPage) {
     return (d) => {
       if (
-          parseInt(d.month, 10) >= firstMonth &&
-          parseInt(d.year, 10) === firstMonthYear + (viewPage - 1)
+        parseInt(d.month, 10) >= firstMonth &&
+        parseInt(d.year, 10) === firstMonthYear + (viewPage - 1)
       ) {
         return true;
       }
 
       return (
-          parseInt(d.month, 10) <= firstMonth &&
-          parseInt(d.year, 10) === firstMonthYear + viewPage
+        parseInt(d.month, 10) <= firstMonth &&
+        parseInt(d.year, 10) === firstMonthYear + viewPage
       );
     };
   }
@@ -390,16 +395,16 @@ class Metrics {
 
     // Current page of results.
     const currentFilter = (
-        this.period === 'day' ?
-            this.filterPeriod(current.month, current.year) :
-            this.filterYearPeriod(firstMonthYear + ((data.viewPage - 1) * data.reverse))
+      this.period === 'day' ?
+        this.filterPeriod(current.month, current.year) :
+        this.filterYearPeriod(firstMonthYear + ((data.viewPage - 1) * data.reverse))
     );
 
     // Next page of results.
     const nextFilter = (
-        this.period === 'day' ?
-            this.filterPeriod(next.month, next.year) :
-            this.filterYearPeriod(firstMonthYear + (data.viewPage * data.reverse))
+      this.period === 'day' ?
+        this.filterPeriod(next.month, next.year) :
+        this.filterYearPeriod(firstMonthYear + (data.viewPage * data.reverse))
     );
 
     // Filter by each.
@@ -469,18 +474,18 @@ class Metrics {
     this.currentRrequest = this.getJsonPage(page, perView);
 
     return this.currentRrequest
-        .then(j => JSON.parse(j))
-        .then(json => {
-          this.total = json.totalPeriods || 0;
-          this.log('parse page ', page);
-          const remaining = this.total - (perView * page);
-          const remainingPages = Math.ceil(remaining / perView);
-          this.saveResults(json, page, remainingPages);
-          this.isLocked = false;
-          deferred.resolve();
-          this.log('resolved,', 'total', this.total, 'remaining requests:', remainingPages);
-          return json;
-        });
+      .then(j => JSON.parse(j))
+      .then(json => {
+        this.total = json.totalPeriods || 0;
+        this.log('parse page ', page);
+        const remaining = this.total - (perView * page);
+        const remainingPages = Math.ceil(remaining / perView);
+        this.saveResults(json, page, remainingPages);
+        this.isLocked = false;
+        deferred.resolve();
+        this.log('resolved,', 'total', this.total, 'remaining requests:', remainingPages);
+        return json;
+      });
   }
 
 }

--- a/assets/js/components/Metrics.js
+++ b/assets/js/components/Metrics.js
@@ -24,7 +24,7 @@ class Metrics {
     this.$next = this.trigger('prev', 'Left', p); // "->" arrow
     this.$prev = this.trigger('next', 'Right', p); // "<-" arrow
 
-    const $grouping = utils.buildElement('div', ['button-collection', 'clearfix'], '', this.$el);
+    const $grouping = utils.buildElement('ol', ['button-collection', 'button-collection--centered', 'button-collection--compact'], '', this.$el);
     this.$dailyButton = this.groupingButton($grouping, 'Daily');
     this.$monthlyButton = this.groupingButton($grouping, 'Monthly');
 
@@ -54,11 +54,15 @@ class Metrics {
 
     // Set the correct button initially.
     if (this.period === 'month') {
-      this.$monthlyButton.classList.add('button-collection__button--active');
-      this.$dailyButton.classList.remove('button-collection__button--active');
+      this.$monthlyButton.classList.add('button--default');
+      this.$monthlyButton.classList.remove('button--outline');
+      this.$dailyButton.classList.add('button--outline');
+      this.$dailyButton.classList.remove('button--default');
     } else {
-      this.$monthlyButton.classList.remove('button-collection__button--active');
-      this.$dailyButton.classList.add('button-collection__button--active');
+      this.$monthlyButton.classList.add('button--outline');
+      this.$monthlyButton.classList.remove('button--default');
+      this.$dailyButton.classList.add('button--default');
+      this.$dailyButton.classList.remove('button--outline');
     }
 
     // Name each chart in format like "downloads-by-day"
@@ -123,17 +127,23 @@ class Metrics {
   }
 
   groupingButton($grouping, label) {
+    const item = utils.buildElement(
+      'li',
+      [
+        'button-collection__item',
+      ],
+      null,
+      $grouping
+    );
     const button = utils.buildElement(
       'a',
       [
         'button',
         'button--outline',
         'button--small',
-        'button-collection__button',
-        'button-collection__button--active'
       ],
       label,
-      $grouping
+      item
     );
     button.href = '#';
     return button;
@@ -144,10 +154,12 @@ class Metrics {
       e.preventDefault();
 
       // Change button style.
-      this.$el
-          .querySelector('.button-collection__button--active')
-          .classList.remove('button-collection__button--active');
-      e.currentTarget.classList.add('button-collection__button--active');
+      const current = this.$el.querySelector('.button--default');
+      current.classList.add('button--outline');
+      current.classList.remove('button--default');
+
+      e.currentTarget.classList.add('button--default');
+      e.currentTarget.classList.remove('button--outline');
       this.log(`changed period to ${period}`);
 
       // Change metric and reload.

--- a/assets/js/components/Metrics.js
+++ b/assets/js/components/Metrics.js
@@ -72,11 +72,11 @@ class Metrics {
 
     // Name each chart in format like "downloads-by-day"
     const availableMetrics = utils.flatten(
-      this.availableCharts.map(
-        chart => this.availablePeriods.map(
-          period => `${chart}-by-${period}`
+        this.availableCharts.map(
+            chart => this.availablePeriods.map(
+                period => `${chart}-by-${period}`
+            )
         )
-      )
     );
 
     this.loadMore = this.loadMore.bind(this);
@@ -169,8 +169,8 @@ class Metrics {
 
       // Change metric and reload.
       return this.changeMetric(
-        this.selected,
-        period
+          this.selected,
+          period
       ).then(() => {
         this.renderView(this.$el, this.getSelectedMetric());
       });
@@ -208,8 +208,8 @@ class Metrics {
 
     this.currentChart = this.currentChart + 1;
     this.changeMetric(
-      this.availableCharts[this.currentChart],
-      this.period
+        this.availableCharts[this.currentChart],
+        this.period
     ).then(() => {
       this.renderView(this.$el, this.getSelectedMetric());
     });
@@ -222,8 +222,8 @@ class Metrics {
 
     this.currentChart = this.currentChart - 1;
     this.changeMetric(
-      this.availableCharts[this.currentChart],
-      this.period
+        this.availableCharts[this.currentChart],
+        this.period
     ).then(() => {
       this.renderView(this.$el, this.getSelectedMetric());
     });
@@ -289,15 +289,15 @@ class Metrics {
 
   getJsonPage(page, perView) {
     return utils.loadData(
-      this.getEndpoint(
-        this.endpoint,
-        this.type,
-        this.id,
-        this.selected,
-        this.period,
-        perView,
-        page
-      )
+        this.getEndpoint(
+            this.endpoint,
+            this.type,
+            this.id,
+            this.selected,
+            this.period,
+            perView,
+            page
+        )
     );
   }
 
@@ -330,9 +330,9 @@ class Metrics {
 
   periodToTimestamp(entry) {
     return Date.UTC(
-      parseInt(entry.year, 10),
-      parseInt(entry.month - 1, 10),
-      parseInt(entry.day ? entry.day : 1, 10)
+        parseInt(entry.year, 10),
+        parseInt(entry.month - 1, 10),
+        parseInt(entry.day ? entry.day : 1, 10)
     );
   }
 
@@ -371,15 +371,15 @@ class Metrics {
   filterMonthPeriod(firstMonth, firstMonthYear, viewPage) {
     return (d) => {
       if (
-        parseInt(d.month, 10) >= firstMonth &&
-        parseInt(d.year, 10) === firstMonthYear + (viewPage - 1)
+          parseInt(d.month, 10) >= firstMonth &&
+          parseInt(d.year, 10) === firstMonthYear + (viewPage - 1)
       ) {
         return true;
       }
 
       return (
-        parseInt(d.month, 10) <= firstMonth &&
-        parseInt(d.year, 10) === firstMonthYear + viewPage
+          parseInt(d.month, 10) <= firstMonth &&
+          parseInt(d.year, 10) === firstMonthYear + viewPage
       );
     };
   }
@@ -395,16 +395,16 @@ class Metrics {
 
     // Current page of results.
     const currentFilter = (
-      this.period === 'day' ?
-        this.filterPeriod(current.month, current.year) :
-        this.filterYearPeriod(firstMonthYear + ((data.viewPage - 1) * data.reverse))
+        this.period === 'day' ?
+            this.filterPeriod(current.month, current.year) :
+            this.filterYearPeriod(firstMonthYear + ((data.viewPage - 1) * data.reverse))
     );
 
     // Next page of results.
     const nextFilter = (
-      this.period === 'day' ?
-        this.filterPeriod(next.month, next.year) :
-        this.filterYearPeriod(firstMonthYear + (data.viewPage * data.reverse))
+        this.period === 'day' ?
+            this.filterPeriod(next.month, next.year) :
+            this.filterYearPeriod(firstMonthYear + (data.viewPage * data.reverse))
     );
 
     // Filter by each.
@@ -474,18 +474,18 @@ class Metrics {
     this.currentRrequest = this.getJsonPage(page, perView);
 
     return this.currentRrequest
-      .then(j => JSON.parse(j))
-      .then(json => {
-        this.total = json.totalPeriods || 0;
-        this.log('parse page ', page);
-        const remaining = this.total - (perView * page);
-        const remainingPages = Math.ceil(remaining / perView);
-        this.saveResults(json, page, remainingPages);
-        this.isLocked = false;
-        deferred.resolve();
-        this.log('resolved,', 'total', this.total, 'remaining requests:', remainingPages);
-        return json;
-      });
+        .then(j => JSON.parse(j))
+        .then(json => {
+          this.total = json.totalPeriods || 0;
+          this.log('parse page ', page);
+          const remaining = this.total - (perView * page);
+          const remainingPages = Math.ceil(remaining / perView);
+          this.saveResults(json, page, remainingPages);
+          this.isLocked = false;
+          deferred.resolve();
+          this.log('resolved,', 'total', this.total, 'remaining requests:', remainingPages);
+          return json;
+        });
   }
 
 }

--- a/assets/sass/patterns/atoms/buttons.scss
+++ b/assets/sass/patterns/atoms/buttons.scss
@@ -36,6 +36,15 @@
 }
 
 .button--outline {
+  @include colors($color-text--reverse, $color-primary, $color-primary);
+  @include padding(15 36 14);
+
+  &:hover {
+    @include colors($color-text--reverse, $color-primary-dark, $color-primary-dark);
+  }
+}
+
+.button--reversed {
   @include colors(transparent, $color-text--reverse);
   @include padding(15 36 14);
 
@@ -82,7 +91,7 @@
   }
 }
 
-.button--outline-inactive {
+.button--reversed-inactive {
   @include colors($color-text--reverse, #909090, #909090);
   border-width: 2px;
 

--- a/assets/sass/patterns/molecules/button-collection.scss
+++ b/assets/sass/patterns/molecules/button-collection.scss
@@ -1,27 +1,34 @@
 @import "../../definitions";
 
+$gutter: 10px;
+
 .button-collection {
   display: table;
+  @supports (display: flex) {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+  }
   @include nospace();
 }
 
 .button-collection--centered {
   margin-left: auto;
   margin-right: auto;
+  padding-left: $gutter;
+  @supports (display: flex) {
+    justify-content: center;
+  }
 }
 
 .button-collection__item {
   float: left;
   list-style: none;
   @include blg-spacing("bottom", "small", "margin");
-  margin-right: 10px;
-
-  .button-collection--compact &,
-  &:last-of-type {
-    margin-right: 0;
-  }
+  margin-right: $gutter;
 
   .button-collection--compact & {
+    margin-right: 0;
     &:not(:first-child) {
       .button {
         border-bottom-left-radius: 0;

--- a/assets/sass/patterns/molecules/button-collection.scss
+++ b/assets/sass/patterns/molecules/button-collection.scss
@@ -2,42 +2,37 @@
 
 .button-collection {
   display: table;
-  margin: 0 auto 10px auto;
-
-  .button-collection__button:nth-child(2) {
-    float: left;
-  }
-
-  :first-child {
-    border-bottom-left-radius: 4px;
-    border-top-left-radius: 4px;
-  }
-
-  :last-child {
-    border-bottom-right-radius: 4px;
-    border-top-right-radius: 4px;
-
-  }
+  @include nospace();
 }
 
-.button-collection__button {
-  border-color: $color-primary;
-  border-radius: 0;
-  color: $color-primary;
+.button-collection--centered {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.button-collection__item {
   float: left;
+  list-style: none;
+  @include blg-spacing("bottom", "small", "margin");
+  margin-right: 10px;
 
-  &:hover {
-    background-color: white;
-    color: $color-primary;
+  .button-collection--compact &,
+  &:last-of-type {
+    margin-right: 0;
   }
-}
 
-.button-collection__button--active {
-  background-color: $color-primary;
-  color: white;
-
-  &:hover {
-    background-color: $color-primary;
-    color: white;
+  .button-collection--compact & {
+    &:not(:first-child) {
+      .button {
+        border-bottom-left-radius: 0;
+        border-top-left-radius: 0;
+      }
+    }
+    &:not(:last-child) {
+      .button {
+        border-bottom-right-radius: 0;
+        border-top-right-radius: 0;
+      }
+    }
   }
 }

--- a/assets/sass/patterns/molecules/carousel-item.scss
+++ b/assets/sass/patterns/molecules/carousel-item.scss
@@ -214,6 +214,9 @@
     bottom: 64px;
     left: 0;
     right: 0;
+    .button {
+      @include margin(0, "bottom");
+    }
   }
 
   .carousel-item__meta {

--- a/assets/sass/patterns/molecules/carousel-item.scss
+++ b/assets/sass/patterns/molecules/carousel-item.scss
@@ -215,7 +215,7 @@
     left: 0;
     right: 0;
     .button {
-      @include margin(0, "bottom");
+      margin-bottom: 0;
     }
   }
 

--- a/source/_patterns/00-atoms/components/button~outline-extra-small.json
+++ b/source/_patterns/00-atoms/components/button~outline-extra-small.json
@@ -1,6 +1,0 @@
-{
-  "text": "Button outline extra small",
-  "classes": "button--outline button--extra-small",
-  "type": "button",
-  "name": "button-name"
-}

--- a/source/_patterns/00-atoms/components/button~outline-inactive.json
+++ b/source/_patterns/00-atoms/components/button~outline-inactive.json
@@ -1,6 +1,0 @@
-{
-  "text": "Button outline inactive",
-  "classes": "button--outline-inactive",
-  "type": "button",
-  "name": "button-name"
-}

--- a/source/_patterns/00-atoms/components/button~outline-small.json
+++ b/source/_patterns/00-atoms/components/button~outline-small.json
@@ -1,6 +1,0 @@
-{
-  "text": "Button outline small",
-  "classes": "button--outline button--small",
-  "type": "button",
-  "name": "button-name"
-}

--- a/source/_patterns/00-atoms/components/button~reversed-extra-small.json
+++ b/source/_patterns/00-atoms/components/button~reversed-extra-small.json
@@ -1,0 +1,6 @@
+{
+  "text": "Button reversed extra small",
+  "classes": "button--reversed button--extra-small",
+  "type": "button",
+  "name": "button-name"
+}

--- a/source/_patterns/00-atoms/components/button~reversed-inactive.json
+++ b/source/_patterns/00-atoms/components/button~reversed-inactive.json
@@ -1,0 +1,6 @@
+{
+  "text": "Button reversed inactive",
+  "classes": "button--reversed-inactive",
+  "type": "button",
+  "name": "button-name"
+}

--- a/source/_patterns/00-atoms/components/button~reversed-small.json
+++ b/source/_patterns/00-atoms/components/button~reversed-small.json
@@ -1,0 +1,6 @@
+{
+  "text": "Button reversed small",
+  "classes": "button--reversed button--small",
+  "type": "button",
+  "name": "button-name"
+}

--- a/source/_patterns/00-atoms/components/button~reversed.json
+++ b/source/_patterns/00-atoms/components/button~reversed.json
@@ -1,0 +1,6 @@
+{
+  "text": "Button reversed",
+  "classes": "button--reversed",
+  "type": "button",
+  "name": "button-name"
+}

--- a/source/_patterns/01-molecules/components/button-collection.json
+++ b/source/_patterns/01-molecules/components/button-collection.json
@@ -1,0 +1,19 @@
+{
+  "buttons": [
+    {
+      "text": "Button 1",
+      "classes": "button--default",
+      "path": "#"
+    },
+    {
+      "text": "Button 2",
+      "classes": "button--default",
+      "path": "#"
+    },
+    {
+      "text": "Button 3",
+      "classes": "button--outline",
+      "path": "#"
+    }
+  ]
+}

--- a/source/_patterns/01-molecules/components/button-collection.mustache
+++ b/source/_patterns/01-molecules/components/button-collection.mustache
@@ -1,0 +1,5 @@
+<ol class="button-collection">
+  {{#buttons}}
+    <li class="button-collection__item">{{>atoms-button}}</li>
+  {{/buttons}}
+</ol>

--- a/source/_patterns/01-molecules/components/button-collection.mustache
+++ b/source/_patterns/01-molecules/components/button-collection.mustache
@@ -1,4 +1,4 @@
-<ol class="button-collection">
+<ol class="button-collection{{#centered}} button-collection--centered{{/centered}}{{#compact}} button-collection--compact{{/compact}}">
   {{#buttons}}
     <li class="button-collection__item">{{>atoms-button}}</li>
   {{/buttons}}

--- a/source/_patterns/01-molecules/components/button-collection.yaml
+++ b/source/_patterns/01-molecules/components/button-collection.yaml
@@ -1,0 +1,14 @@
+assets:
+  css:
+    - button-collection.css
+    - $ref: ../../00-atoms/components/button.yaml#/assets/css
+  js: []
+schema:
+  $schema: http://json-schema.org/draft-04/schema#
+  type: object
+  properties:
+    buttons:
+      type: array
+      minItems: 1
+      items:
+        $ref: ../../00-atoms/components/button.yaml#/schema

--- a/source/_patterns/01-molecules/components/button-collection.yaml
+++ b/source/_patterns/01-molecules/components/button-collection.yaml
@@ -7,8 +7,14 @@ schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object
   properties:
+    compact:
+      type: boolean
+    centered:
+      type: boolean
     buttons:
       type: array
       minItems: 1
       items:
         $ref: ../../00-atoms/components/button.yaml#/schema
+  required:
+    - buttons

--- a/source/_patterns/01-molecules/components/button-collection~centered.json
+++ b/source/_patterns/01-molecules/components/button-collection~centered.json
@@ -1,0 +1,20 @@
+{
+  "centered": true,
+  "buttons": [
+    {
+      "text": "Button 1",
+      "classes": "button--default",
+      "path": "#"
+    },
+    {
+      "text": "Button 2",
+      "classes": "button--default",
+      "path": "#"
+    },
+    {
+      "text": "Button 3",
+      "classes": "button--outline",
+      "path": "#"
+    }
+  ]
+}

--- a/source/_patterns/01-molecules/components/button-collection~compact.json
+++ b/source/_patterns/01-molecules/components/button-collection~compact.json
@@ -1,0 +1,20 @@
+{
+  "compact": true,
+  "buttons": [
+    {
+      "text": "Button 1",
+      "classes": "button--default",
+      "path": "#"
+    },
+    {
+      "text": "Button 2",
+      "classes": "button--default",
+      "path": "#"
+    },
+    {
+      "text": "Button 3",
+      "classes": "button--outline",
+      "path": "#"
+    }
+  ]
+}

--- a/source/_patterns/01-molecules/components/carousel-item.json
+++ b/source/_patterns/01-molecules/components/carousel-item.json
@@ -17,7 +17,7 @@
   "button": {
     "text": "Read article",
     "path": "#link-to-article",
-    "classes": "button--outline button--small"
+    "classes": "button--reversed button--small"
   },
   "meta": {
     "url": "#",

--- a/source/_patterns/02-organisms/components/carousel.json
+++ b/source/_patterns/02-organisms/components/carousel.json
@@ -22,7 +22,7 @@
       "button": {
         "text": "Read article",
         "path": "#link-to-article",
-        "classes": "button--outline button--small"
+        "classes": "button--reversed button--small"
       },
       "meta": {
         "url": "#",
@@ -58,7 +58,7 @@
       "button": {
         "text": "Read article",
         "path": "#link-to-article",
-        "classes": "button--outline button--small"
+        "classes": "button--reversed button--small"
       },
       "meta": {
         "url": "#",
@@ -98,7 +98,7 @@
       "button": {
         "text": "Read article",
         "path": "#link-to-article",
-        "classes": "button--outline button--small"
+        "classes": "button--reversed button--small"
       },
       "meta": {
         "url": "#LinkToResearchArticles",

--- a/source/_patterns/02-organisms/content-headers/content-header~background-with-audio-player.json
+++ b/source/_patterns/02-organisms/content-headers/content-header~background-with-audio-player.json
@@ -49,7 +49,7 @@
   "button": {
     "text": "Subscribe",
     "path": "#",
-    "classes": "button--outline button--small"
+    "classes": "button--reversed button--small"
   },
   "meta": {
     "url": "#",

--- a/source/_patterns/02-organisms/content-headers/content-header~background-with-image-credit-and-audio-player.json
+++ b/source/_patterns/02-organisms/content-headers/content-header~background-with-image-credit-and-audio-player.json
@@ -52,7 +52,7 @@
   "button": {
     "text": "Subscribe",
     "path": "#",
-    "classes": "button--outline button--small"
+    "classes": "button--reversed button--small"
   },
   "meta": {
     "url": "#",

--- a/source/_patterns/02-organisms/content-headers/content-header~background-with-image-credit-overlay.json
+++ b/source/_patterns/02-organisms/content-headers/content-header~background-with-image-credit-overlay.json
@@ -53,7 +53,7 @@
   "button": {
     "text": "Subscribe",
     "path": "#",
-    "classes": "button--outline button--small"
+    "classes": "button--reversed button--small"
   },
   "meta": {
     "url": "#",

--- a/source/_patterns/02-organisms/content-headers/content-header~background-with-image-credit.json
+++ b/source/_patterns/02-organisms/content-headers/content-header~background-with-image-credit.json
@@ -52,7 +52,7 @@
   "button": {
     "text": "Subscribe",
     "path": "#",
-    "classes": "button--outline button--small"
+    "classes": "button--reversed button--small"
   },
   "meta": {
     "url": "#",

--- a/source/_patterns/02-organisms/content-headers/content-header~background.json
+++ b/source/_patterns/02-organisms/content-headers/content-header~background.json
@@ -48,7 +48,7 @@
   "button": {
     "text": "Subscribe",
     "path": "#",
-    "classes": "button--outline button--small"
+    "classes": "button--reversed button--small"
   },
   "meta": {
     "url": "#",

--- a/source/_patterns/02-organisms/content-headers/content-header~collection.json
+++ b/source/_patterns/02-organisms/content-headers/content-header~collection.json
@@ -25,7 +25,7 @@
   "button": {
     "text": "Subscribe",
     "path": "#",
-    "classes": "button--outline button--small"
+    "classes": "button--reversed button--small"
   },
   "meta": {
     "url": "#",

--- a/source/_patterns/04-pages/collection.json
+++ b/source/_patterns/04-pages/collection.json
@@ -154,7 +154,7 @@
     "button": {
       "text": "Subscribe",
       "path": "#",
-      "classes": "button--outline button--small"
+      "classes": "button--reversed button--small"
     },
     "image": {
       "fallback": {

--- a/source/_patterns/04-pages/home.json
+++ b/source/_patterns/04-pages/home.json
@@ -154,7 +154,7 @@
         "button": {
           "text": "Read article",
           "path": "#link-to-article",
-          "classes": "button--outline button--small"
+          "classes": "button--reversed button--small"
         },
         "meta": {
           "url": "#",
@@ -190,7 +190,7 @@
         "button": {
           "text": "Read article",
           "path": "#link-to-article",
-          "classes": "button--outline button--small"
+          "classes": "button--reversed button--small"
         },
         "meta": {
           "url": "#",
@@ -230,7 +230,7 @@
         "button": {
           "text": "Read article",
           "path": "#link-to-article",
-          "classes": "button--outline button--small"
+          "classes": "button--reversed button--small"
         },
         "meta": {
           "url": "#LinkToResearchArticles",

--- a/source/_patterns/04-pages/labs.json
+++ b/source/_patterns/04-pages/labs.json
@@ -139,7 +139,7 @@
     "button": {
       "text": "Subscribe",
       "path": "#",
-      "classes": "button--outline button--small"
+      "classes": "button--reversed button--small"
     },
     "image": {
       "fallback": {

--- a/source/_patterns/04-pages/msa.json
+++ b/source/_patterns/04-pages/msa.json
@@ -140,7 +140,7 @@
     "button": {
       "text": "Subscribe",
       "url": "#",
-      "classes": "button--outline button--small"
+      "classes": "button--reversed button--small"
     },
     "image": {
       "fallback": {


### PR DESCRIPTION
This is the long-way round getting a margin underneath buttons when they're part of the body content.

For future use (imagining buttons side by side), I decided to create a pattern that wrapped one or more buttons then add the margin to that, rather than try and add it to some buttons and not others (eg in the site header). Turns out that the Metrics pattern already had an informal pattern called Button Collection, so I've sorted that out.

I've also renamed the `button--outline` variant to `button--reversed`, then created a new variant called `button--outline` which is just an outline (not reversed as well!).