### PR TITLE
Remove bottom padding from content headers when there's an image

### DIFF
--- a/assets/sass/patterns/organisms/content-header.scss
+++ b/assets/sass/patterns/organisms/content-header.scss
@@ -40,6 +40,7 @@
   color: $color-text--reverse;
   height: #{$content-header-image-height--narrow-screen}px;
   overflow: hidden;
+  padding-bottom: 0;
 
   @media only all and (min-width: #{get-rem-from-px($bkpt-site--medium)}em) {
     height: #{$content-header-image-height--medium-width-screen}px;


### PR DESCRIPTION
This adds to the set height, which isn't meant (see https://github.com/elifesciences/journal/pull/831#issuecomment-367246813). The content is all positioned anyway, so it's also redundant.