### PR TITLE
Grid listing css grid

### DIFF
--- a/assets/sass/patterns/organisms/grid-listing.scss
+++ b/assets/sass/patterns/organisms/grid-listing.scss
@@ -6,7 +6,7 @@
   @include clearfix();
   list-style: none;
 
-  //display: grid;
+  display: grid;
 
   margin: 0 auto;
 
@@ -17,27 +17,26 @@
 
   @media only all and (min-width: #{get-rem-from-px($bkpt-site--medium)}em) {
 
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: repeat(2, 1fr);
     grid-column-gap: 2.25rem;
     justify-content: center;
 
-    //@supports (display: grid) {
-    //
-    //  &:before,
-    //  &:after {
-    //    display: none;
-    //  }
-    //
-    //}
+    // Override the effects of the clearfix which is required for the grid fallback
+    @supports (display: grid) {
+      &:before,
+      &:after {
+        display: none;
+      }
+
+    }
   }
 
   @media only all and (min-width: #{get-rem-from-px($bkpt-site--wide)}em) {
-    grid-template-columns: 1fr 1fr 1fr;
-
+    grid-template-columns: repeat(3, 1fr);
   }
 
   @media only all and (min-width: #{get-rem-from-px($bkpt-site--x-wide)}em) {
-    grid-template-columns: 1fr 1fr 1fr 1fr;
+    grid-template-columns: repeat(4, 1fr);
   }
 
 }
@@ -53,12 +52,20 @@
   // 2 col
   @media only all and (min-width: #{get-rem-from-px($bkpt-site--medium)}em) {
 
-    @include margin($grid-listing-spacing-measure, "right");
     @include blg-spacing("bottom", "extra-small", "margin");
-    width: calc((100% - #{$grid-listing-spacing-measure}px) / 2 - 0.1px); // -0.1px avoids rounding problems in IE
+
+    @include margin($grid-listing-spacing-measure, "right");
+    @supports (display: grid) {
+      margin-right: 0;
+    }
 
     &:nth-child(2n) {
       margin-right: 0;
+    }
+
+    width: calc((100% - #{$grid-listing-spacing-measure}px) / 2 - 0.1px); // -0.1px avoids rounding problems in IE
+    @supports (display: grid) {
+      width: auto;
     }
 
   }
@@ -66,14 +73,24 @@
   // 3 col
   @media only all and (min-width: #{get-rem-from-px($bkpt-site--wide)}em) {
     @include margin($grid-listing-spacing-measure, "right");
+    @supports (display: grid) {
+      margin-right: 0;
+    }
+
+    &:nth-child(2n) {
+      @include margin($grid-listing-spacing-measure, "right");
+      @supports (display: grid) {
+        margin-right: 0;
+      }
+    }
+
+    &:nth-child(3n) {
+      margin-right: 0;
+    }
+
     width: calc((100% - #{2 * $grid-listing-spacing-measure}px) / 3 - 0.1px); // -0.1px avoids rounding problems in IE
-
-    &:nth-child(2n) {
-      @include margin($grid-listing-spacing-measure, "right");
-    }
-
-    &:nth-child(3n) {
-      margin-right: 0;
+    @supports (display: grid) {
+      width: auto;
     }
 
   }
@@ -81,128 +98,31 @@
   // 4 col
   @media only all and (min-width: #{get-rem-from-px($bkpt-site--x-wide)}em) {
     @include margin($grid-listing-spacing-measure, "right");
+    @supports (display: grid) {
+      margin-right: 0;
+    }
+
+    &:nth-child(2n),
+    &:nth-child(3n) {
+      @include margin($grid-listing-spacing-measure, "right");
+      @supports (display: grid) {
+        margin-right: 0;
+      }
+    }
+
+    &:nth-child(4n) {
+      margin-right: 0;
+    }
+
     width: calc((100% - #{3 * $grid-listing-spacing-measure}px) / 4 - 0.1px); // -0.1px avoids rounding problems in IE
-
-    &:nth-child(2n),
-    &:nth-child(3n) {
-      @include margin($grid-listing-spacing-measure, "right");
-    }
-
-    &:nth-child(4n) {
-      margin-right: 0;
+    @supports (display: grid) {
+      width: auto;
     }
 
   }
-}
-
-/*
-.grid-listing {
-  list-style: none;
-  margin: 0 auto;
-  padding-left: 0;
-  // Gives the effect of medium-to-large due to 24px already on the bottom of the list items
-  @include blg-margin-bottom--small-to-medium();
-
-  @supports (display: flex) {
-    display: flex;
-    flex-wrap: wrap;
-  }
-}
-
-.grid-listing-item {
-  margin: 0;
-  @include blg-spacing("bottom", "extra-small", "margin");
-  @include blg-spacing("top", "small");
-  @include constrain-width($max-width-block-link, "max");
-  width: 100%;
-
-  // 2 col
-  @media only all and (min-width: #{get-rem-from-px($bkpt-site--medium)}em) {
-
-    float: left;
-    margin-top: 0;
-    @include margin($grid-listing-spacing-measure, "right");
-    @include blg-spacing("bottom", "extra-small", "margin");
-    margin-left: 0;
-    width: calc((100% - #{$grid-listing-spacing-measure}px) / 2 - 0.1px); // -0.1px avoids rounding problems in IE
-
-    &:nth-child(2n) {
-      margin-right: 0;
-      @supports (display: flex) {
-        width: auto;
-        flex: 1;
-      }
-    }
-
-    .archive-nav-link {
-      height: 437px;
-
-      @supports (display: flex) {
-        height: auto;
-      }
-    }
-
-  }
-
-  // 3 col
-  @media only all and (min-width: #{get-rem-from-px($bkpt-site--wide)}em) {
-    margin-top: 0;
-    @include margin($grid-listing-spacing-measure, "right");
-    @include blg-spacing("bottom", "extra-small", "margin");
-    margin-left: 0;
-    width: calc((100% - #{2 * $grid-listing-spacing-measure}px) / 3 - 0.1px);
-
-    &:nth-child(2n) {
-      @include margin($grid-listing-spacing-measure, "right");
-      @supports (display: flex) {
-        width: calc((100% - #{2 * $grid-listing-spacing-measure}px) / 3);
-        flex: none;
-      }
-    }
-
-    &:nth-child(3n) {
-      margin-right: 0;
-      @supports (display: flex) {
-        width: auto;
-        flex: 1;
-      }
-    }
-
-  }
-
-  // 4 col
-  @media only all and (min-width: #{get-rem-from-px($bkpt-site--x-wide)}em) {
-
-    margin-top: 0;
-    @include margin($grid-listing-spacing-measure, "right");
-    @include blg-spacing("bottom", "extra-small", "margin");
-    margin-left: 0;
-
-    width: calc((100% - #{3 * $grid-listing-spacing-measure}px) / 4 - 0.1px);
-
-    &:nth-child(2n),
-    &:nth-child(3n) {
-      @include margin($grid-listing-spacing-measure, "right");
-      @supports (display: flex) {
-        width: calc((100% - #{3 * $grid-listing-spacing-measure}px) / 4);
-        flex: none;
-      }
-    }
-
-    &:nth-child(4n) {
-      margin-right: 0;
-      @supports (display: flex) {
-        width: auto;
-        flex: 1;
-      }
-    }
-
-  }
-
 }
 
 .grid-listing__pagination {
   @include blg-margin-bottom--medium-to-large();
   width: 100%;
 }
-*/

--- a/assets/sass/patterns/organisms/grid-listing.scss
+++ b/assets/sass/patterns/organisms/grid-listing.scss
@@ -2,6 +2,8 @@
 @import "../../layout/grid";
 
 .grid-listing {
+
+  // Fallback for clients that don't support css grid
   @include clearfix();
 
   @supports (display: grid) {
@@ -21,7 +23,7 @@
     grid-row-gap: #{get-rem-from-px($blg-space-extra-small-in-px)}rem;
     justify-content: center;
 
-    // Override the effects of the clearfix which is required for the grid fallback
+    // Supporting clients don't need clearfix
     @supports (display: grid) {
       &:before,
       &:after {

--- a/assets/sass/patterns/organisms/grid-listing.scss
+++ b/assets/sass/patterns/organisms/grid-listing.scss
@@ -2,6 +2,53 @@
 @import "../../layout/grid";
 
 .grid-listing {
+
+  @include clearfix();
+  list-style: none;
+
+  display: grid;
+
+  padding-left: 0;
+
+  // Gives the effect of medium-to-large due to 24px already on the bottom of the list items
+  @include blg-margin-bottom--small-to-medium();
+
+  @media only all and (min-width: #{get-rem-from-px($bkpt-site--medium)}em) {
+
+    grid-template-columns: 1fr 1fr;
+    grid-column-gap: 2.25rem;
+    justify-content: center;
+
+    @supports (display: grid) {
+
+      &:before,
+      &:after {
+        display: none;
+      }
+
+    }
+  }
+
+  @media only all and (min-width: #{get-rem-from-px($bkpt-site--wide)}em) {
+    grid-template-columns: 1fr 1fr 1fr;
+  }
+
+  @media only all and (min-width: #{get-rem-from-px($bkpt-site--x-wide)}em) {
+    grid-template-columns: 1fr 1fr 1fr 1fr;
+  }
+
+}
+
+.grid-listing-item {
+  margin: 0;
+  @include blg-spacing("bottom", "extra-small", "margin");
+  @include blg-spacing("top", "small");
+  @include constrain-width($max-width-block-link, "max");
+  width: 100%;
+}
+
+/*
+.grid-listing {
   list-style: none;
   margin: 0 auto;
   padding-left: 0;
@@ -110,3 +157,4 @@
   @include blg-margin-bottom--medium-to-large();
   width: 100%;
 }
+*/

--- a/assets/sass/patterns/organisms/grid-listing.scss
+++ b/assets/sass/patterns/organisms/grid-listing.scss
@@ -88,8 +88,8 @@
     width: calc((100% - #{3 * $grid-listing-spacing-measure}px) / 4 - 0.1px); // -0.1px avoids rounding problems in IE
   }
 
-    @supports (display: grid) {
-      &:nth-child(n) {
+  @supports (display: grid) {
+    &:nth-child(n) {
       margin-right: 0;
       width: auto;
     }

--- a/assets/sass/patterns/organisms/grid-listing.scss
+++ b/assets/sass/patterns/organisms/grid-listing.scss
@@ -16,6 +16,7 @@
   @media only all and (min-width: #{get-rem-from-px($bkpt-site--medium)}em) {
     grid-template-columns: repeat(2, 1fr);
     grid-column-gap: 2.25rem;
+    grid-row-gap: #{get-rem-from-px($blg-space-extra-small-in-px)};
     justify-content: center;
 
     // Override the effects of the clearfix which is required for the grid fallback
@@ -40,14 +41,12 @@
 .grid-listing-item {
   float: left;
   margin: 0;
-  @include blg-spacing("bottom", "extra-small", "margin");
   @include blg-spacing("top", "small");
   width: 100%;
   @include constrain-width($max-width-block-link, "max");
 
   // 2 col
   @media only all and (min-width: #{get-rem-from-px($bkpt-site--medium)}em) {
-    @include blg-spacing("bottom", "extra-small", "margin");
     @include margin($grid-listing-spacing-measure, "right");
 
     &:nth-child(2n) {

--- a/assets/sass/patterns/organisms/grid-listing.scss
+++ b/assets/sass/patterns/organisms/grid-listing.scss
@@ -6,7 +6,9 @@
   @include clearfix();
   list-style: none;
 
-  display: grid;
+  //display: grid;
+
+  margin: 0 auto;
 
   padding-left: 0;
 
@@ -19,18 +21,19 @@
     grid-column-gap: 2.25rem;
     justify-content: center;
 
-    @supports (display: grid) {
-
-      &:before,
-      &:after {
-        display: none;
-      }
-
-    }
+    //@supports (display: grid) {
+    //
+    //  &:before,
+    //  &:after {
+    //    display: none;
+    //  }
+    //
+    //}
   }
 
   @media only all and (min-width: #{get-rem-from-px($bkpt-site--wide)}em) {
     grid-template-columns: 1fr 1fr 1fr;
+
   }
 
   @media only all and (min-width: #{get-rem-from-px($bkpt-site--x-wide)}em) {
@@ -40,11 +43,56 @@
 }
 
 .grid-listing-item {
+  float: left;
   margin: 0;
   @include blg-spacing("bottom", "extra-small", "margin");
   @include blg-spacing("top", "small");
-  @include constrain-width($max-width-block-link, "max");
   width: 100%;
+  @include constrain-width($max-width-block-link, "max");
+
+  // 2 col
+  @media only all and (min-width: #{get-rem-from-px($bkpt-site--medium)}em) {
+
+    @include margin($grid-listing-spacing-measure, "right");
+    @include blg-spacing("bottom", "extra-small", "margin");
+    width: calc((100% - #{$grid-listing-spacing-measure}px) / 2 - 0.1px); // -0.1px avoids rounding problems in IE
+
+    &:nth-child(2n) {
+      margin-right: 0;
+    }
+
+  }
+
+  // 3 col
+  @media only all and (min-width: #{get-rem-from-px($bkpt-site--wide)}em) {
+    @include margin($grid-listing-spacing-measure, "right");
+    width: calc((100% - #{2 * $grid-listing-spacing-measure}px) / 3 - 0.1px); // -0.1px avoids rounding problems in IE
+
+    &:nth-child(2n) {
+      @include margin($grid-listing-spacing-measure, "right");
+    }
+
+    &:nth-child(3n) {
+      margin-right: 0;
+    }
+
+  }
+
+  // 4 col
+  @media only all and (min-width: #{get-rem-from-px($bkpt-site--x-wide)}em) {
+    @include margin($grid-listing-spacing-measure, "right");
+    width: calc((100% - #{3 * $grid-listing-spacing-measure}px) / 4 - 0.1px); // -0.1px avoids rounding problems in IE
+
+    &:nth-child(2n),
+    &:nth-child(3n) {
+      @include margin($grid-listing-spacing-measure, "right");
+    }
+
+    &:nth-child(4n) {
+      margin-right: 0;
+    }
+
+  }
 }
 
 /*

--- a/assets/sass/patterns/organisms/grid-listing.scss
+++ b/assets/sass/patterns/organisms/grid-listing.scss
@@ -27,7 +27,6 @@
       &:after {
         display: none;
       }
-
     }
   }
 
@@ -55,33 +54,20 @@
     @include blg-spacing("bottom", "extra-small", "margin");
 
     @include margin($grid-listing-spacing-measure, "right");
-    @supports (display: grid) {
-      margin-right: 0;
-    }
 
     &:nth-child(2n) {
       margin-right: 0;
     }
 
     width: calc((100% - #{$grid-listing-spacing-measure}px) / 2 - 0.1px); // -0.1px avoids rounding problems in IE
-    @supports (display: grid) {
-      width: auto;
-    }
-
   }
 
   // 3 col
   @media only all and (min-width: #{get-rem-from-px($bkpt-site--wide)}em) {
     @include margin($grid-listing-spacing-measure, "right");
-    @supports (display: grid) {
-      margin-right: 0;
-    }
 
     &:nth-child(2n) {
       @include margin($grid-listing-spacing-measure, "right");
-      @supports (display: grid) {
-        margin-right: 0;
-      }
     }
 
     &:nth-child(3n) {
@@ -89,10 +75,6 @@
     }
 
     width: calc((100% - #{2 * $grid-listing-spacing-measure}px) / 3 - 0.1px); // -0.1px avoids rounding problems in IE
-    @supports (display: grid) {
-      width: auto;
-    }
-
   }
 
   // 4 col
@@ -105,9 +87,6 @@
     &:nth-child(2n),
     &:nth-child(3n) {
       @include margin($grid-listing-spacing-measure, "right");
-      @supports (display: grid) {
-        margin-right: 0;
-      }
     }
 
     &:nth-child(4n) {
@@ -115,11 +94,15 @@
     }
 
     width: calc((100% - #{3 * $grid-listing-spacing-measure}px) / 4 - 0.1px); // -0.1px avoids rounding problems in IE
+  }
+
+  &:nth-child(n) {
     @supports (display: grid) {
+      margin-right: 0;
       width: auto;
     }
-
   }
+
 }
 
 .grid-listing__pagination {

--- a/assets/sass/patterns/organisms/grid-listing.scss
+++ b/assets/sass/patterns/organisms/grid-listing.scss
@@ -2,21 +2,18 @@
 @import "../../layout/grid";
 
 .grid-listing {
-
   @include clearfix();
-  list-style: none;
 
   display: grid;
 
+  list-style: none;
   margin: 0 auto;
-
   padding-left: 0;
 
   // Gives the effect of medium-to-large due to 24px already on the bottom of the list items
   @include blg-margin-bottom--small-to-medium();
 
   @media only all and (min-width: #{get-rem-from-px($bkpt-site--medium)}em) {
-
     grid-template-columns: repeat(2, 1fr);
     grid-column-gap: 2.25rem;
     justify-content: center;
@@ -50,9 +47,7 @@
 
   // 2 col
   @media only all and (min-width: #{get-rem-from-px($bkpt-site--medium)}em) {
-
     @include blg-spacing("bottom", "extra-small", "margin");
-
     @include margin($grid-listing-spacing-measure, "right");
 
     &:nth-child(2n) {
@@ -80,9 +75,6 @@
   // 4 col
   @media only all and (min-width: #{get-rem-from-px($bkpt-site--x-wide)}em) {
     @include margin($grid-listing-spacing-measure, "right");
-    @supports (display: grid) {
-      margin-right: 0;
-    }
 
     &:nth-child(2n),
     &:nth-child(3n) {
@@ -96,8 +88,8 @@
     width: calc((100% - #{3 * $grid-listing-spacing-measure}px) / 4 - 0.1px); // -0.1px avoids rounding problems in IE
   }
 
-  &:nth-child(n) {
     @supports (display: grid) {
+      &:nth-child(n) {
       margin-right: 0;
       width: auto;
     }

--- a/assets/sass/patterns/organisms/grid-listing.scss
+++ b/assets/sass/patterns/organisms/grid-listing.scss
@@ -4,7 +4,9 @@
 .grid-listing {
   @include clearfix();
 
-  display: grid;
+  @supports (display: grid) {
+    display: grid;
+  }
 
   list-style: none;
   margin: 0 auto;

--- a/assets/sass/patterns/organisms/grid-listing.scss
+++ b/assets/sass/patterns/organisms/grid-listing.scss
@@ -8,6 +8,7 @@
 
   @supports (display: grid) {
     display: grid;
+    @include blg-spacing("top", "small");
   }
 
   list-style: none;
@@ -20,7 +21,7 @@
   @media only all and (min-width: #{get-rem-from-px($bkpt-site--medium)}em) {
     grid-template-columns: repeat(2, 1fr);
     grid-column-gap: 2.25rem;
-    grid-row-gap: #{get-rem-from-px($blg-space-extra-small-in-px)}rem;
+    grid-row-gap: #{get-rem-from-px($blg-space-smallish-in-px)}rem;
     justify-content: center;
 
     // Supporting clients don't need clearfix
@@ -45,7 +46,10 @@
 .grid-listing-item {
   float: left;
   margin: 0;
+
+  // Removed later if grid supported
   @include blg-spacing("top", "small");
+
   width: 100%;
   @include constrain-width($max-width-block-link, "max");
 
@@ -93,7 +97,7 @@
 
   @supports (display: grid) {
     &:nth-child(n) {
-      margin-right: 0;
+      @include nospace();
       width: auto;
     }
   }

--- a/assets/sass/patterns/organisms/grid-listing.scss
+++ b/assets/sass/patterns/organisms/grid-listing.scss
@@ -18,7 +18,7 @@
   @media only all and (min-width: #{get-rem-from-px($bkpt-site--medium)}em) {
     grid-template-columns: repeat(2, 1fr);
     grid-column-gap: 2.25rem;
-    grid-row-gap: #{get-rem-from-px($blg-space-extra-small-in-px)};
+    grid-row-gap: #{get-rem-from-px($blg-space-extra-small-in-px)}rem;
     justify-content: center;
 
     // Override the effects of the clearfix which is required for the grid fallback

--- a/source/_patterns/02-organisms/components/grid-listing.mustache
+++ b/source/_patterns/02-organisms/components/grid-listing.mustache
@@ -1,5 +1,5 @@
 {{#heading}}{{> atoms-list-heading}}{{/heading}}
-<ol class="grid-listing clearfix{{#classes}} {{classes}}{{/classes}}"{{#id}} id="{{id}}"{{/id}}>
+<ol class="grid-listing{{#classes}} {{classes}}{{/classes}}"{{#id}} id="{{id}}"{{/id}}>
   {{#blockLinks}}
     <li class="grid-listing-item grid-listing-item--block-link">
       {{> atoms-block-link}}


### PR DESCRIPTION
Replaces `flexbox` with css `grid` in the `grid-listing` pattern. Uses a float-based fallback for non-supporting clients.