### PR TITLE
Only use CSS grid when grid gap property is supported

### DIFF
--- a/assets/sass/patterns/organisms/grid-listing.scss
+++ b/assets/sass/patterns/organisms/grid-listing.scss
@@ -5,7 +5,7 @@
   // Fallback for clients that don't support css grid
   @include clearfix();
 
-  @supports (display: grid) {
+  @supports (grid-gap: 0) {
     display: grid;
     @include blg-spacing("top", "small");
   }
@@ -24,7 +24,7 @@
     justify-content: center;
 
     // Supporting clients don't need clearfix
-    @supports (display: grid) {
+    @supports (grid-gap: 0) {
       &:before,
       &:after {
         display: none;
@@ -94,7 +94,7 @@
     width: calc((100% - #{3 * $grid-listing-spacing-measure}px) / 4 - 0.1px); // -0.1px avoids rounding problems in IE
   }
 
-  @supports (display: grid) {
+  @supports (grid-gap: 0) {
     &:nth-child(n) {
       @include nospace();
       width: auto;


### PR DESCRIPTION
Changes the feature query used to activate css grid in order to avoid browsers using the feature when they only offer a partial implementation. (Looking at you, Edge < 16.)