### PR TITLE
Prevent FOIT

### DIFF
--- a/assets/fonts/fonts.css
+++ b/assets/fonts/fonts.css
@@ -1,6 +1,7 @@
 
 /* Demi */
 @font-face {
+  font-display: swap;
   font-family: "Avenir Next Webfont";
   src: url("249228f0-61ac-40cc-a5a5-5609c9816e3f.woff2") format("woff2"),
     url("efba18ed-80cc-49c4-997a-fbb140739d19.woff") format("woff");
@@ -9,6 +10,7 @@
 
 /* Medium */
 @font-face {
+  font-display: swap;
   font-family: "Avenir Next Webfont";
   src: url("627fbb5a-3bae-4cd9-b617-2f923e29d55e.woff2") format("woff2"),
   url("f26faddb-86cc-4477-a253-1e1287684336.woff") format("woff");

--- a/assets/fonts/fonts.css
+++ b/assets/fonts/fonts.css
@@ -1,7 +1,7 @@
 
 /* Demi */
 @font-face {
-  font-display: swap;
+  font-display: fallback;
   font-family: "Avenir Next Webfont";
   src: url("249228f0-61ac-40cc-a5a5-5609c9816e3f.woff2") format("woff2"),
     url("efba18ed-80cc-49c4-997a-fbb140739d19.woff") format("woff");
@@ -10,7 +10,7 @@
 
 /* Medium */
 @font-face {
-  font-display: swap;
+  font-display: fallback;
   font-family: "Avenir Next Webfont";
   src: url("627fbb5a-3bae-4cd9-b617-2f923e29d55e.woff2") format("woff2"),
   url("f26faddb-86cc-4477-a253-1e1287684336.woff") format("woff");


### PR DESCRIPTION
Rather than the text not appearing, this renders it in the fallback then re-renders it when the font is loaded.

We might want to consider `optional`, which won't re-render if the font is slow to load (but since it's _very_ cacheable it might be available on the next page load).