### PR TITLE
Only store the assets in the assets container

### DIFF
--- a/Dockerfile.assets
+++ b/Dockerfile.assets
@@ -1,40 +1,5 @@
-# Debian oldoldstable, support ends in May 2018
-# we need this for Ruby 1.9.x at the moment
-FROM node:6.13.1-wheezy AS assets-builder
-
-# TODO: base image
-USER root
-RUN useradd -ms /bin/bash -G www-data elife && \
-    chown elife:elife /srv && \
-    mkdir /srv/bin && \
-    chown elife:elife /srv/bin && \
-    mkdir -p /var/www && \
-    chown www-data:www-data /var/www
-ENV PATH=/srv/bin:${PATH}
-# end base image
-
-# potentially base image
-RUN npm install -g gulp-cli
-# end potentially base image
-
-RUN apt-get update && apt-get install -y \
-    bzip2 \
-    g++ \
-    make \
-    ruby \
-    ruby-dev 
-
-RUN gem install compass
-
-USER elife
-ENV PROJECT_FOLDER=/srv/pattern-library
-RUN mkdir ${PROJECT_FOLDER}
-WORKDIR ${PROJECT_FOLDER}
-COPY --chown=elife:elife \
-    package.json \
-    npm-shrinkwrap.json \
-    ${PROJECT_FOLDER}/
-RUN npm install
+ARG image_tag=latest
+FROM elifesciences/pattern-library_node:${image_tag} AS assets-builder
 ARG environment=production
 
 COPY --chown=elife:elife \

--- a/Dockerfile.assets
+++ b/Dockerfile.assets
@@ -1,6 +1,6 @@
 # Debian oldoldstable, support ends in May 2018
 # we need this for Ruby 1.9.x at the moment
-FROM node:6.13.1-wheezy
+FROM node:6.13.1-wheezy AS assets-builder
 
 # TODO: base image
 USER root
@@ -58,3 +58,12 @@ COPY --chown=elife:elife source/ ${PROJECT_FOLDER}/source
 
 COPY --chown=elife:elife assets/sass ${PROJECT_FOLDER}/assets/sass
 RUN gulp --environment ${environment} generateStyles
+
+FROM busybox:1.28.3
+ENV PROJECT_FOLDER=/srv/pattern-library
+RUN mkdir -p ${PROJECT_FOLDER}
+WORKDIR ${PROJECT_FOLDER}
+
+COPY --from=assets-builder \
+    --chown=root:root \
+    /srv/pattern-library/source/ ${PROJECT_FOLDER}/source

--- a/Dockerfile.assets
+++ b/Dockerfile.assets
@@ -1,28 +1,5 @@
 ARG image_tag=latest
-FROM elifesciences/pattern-library_node:${image_tag} AS assets-builder
-ARG environment=production
-
-COPY --chown=elife:elife \
-    .babelrc \
-    .jscsrc \
-    .jshintrc \
-    .stylelintrc \
-    config.rb \
-    gulpfile.js \
-    ${PROJECT_FOLDER}/
-
-COPY --chown=elife:elife assets/fonts/ ${PROJECT_FOLDER}/assets/fonts
-RUN gulp --environment ${environment} fonts
-COPY --chown=elife:elife assets/img/ ${PROJECT_FOLDER}/assets/img
-RUN gulp --environment ${environment} img
-
-COPY --chown=elife:elife assets/js/ ${PROJECT_FOLDER}/assets/js
-RUN gulp --environment ${environment} js
-
-COPY --chown=elife:elife source/ ${PROJECT_FOLDER}/source
-
-COPY --chown=elife:elife assets/sass ${PROJECT_FOLDER}/assets/sass
-RUN gulp --environment ${environment} generateStyles
+FROM elifesciences/pattern-library_assets-builder:${image_tag} AS assets-builder
 
 FROM busybox:1.28.3
 ENV PROJECT_FOLDER=/srv/pattern-library

--- a/Dockerfile.assets-builder
+++ b/Dockerfile.assets-builder
@@ -35,3 +35,26 @@ COPY --chown=elife:elife \
     npm-shrinkwrap.json \
     ${PROJECT_FOLDER}/
 RUN npm install
+ARG environment=production
+
+COPY --chown=elife:elife \
+    .babelrc \
+    .jscsrc \
+    .jshintrc \
+    .stylelintrc \
+    config.rb \
+    gulpfile.js \
+    ${PROJECT_FOLDER}/
+
+COPY --chown=elife:elife assets/fonts/ ${PROJECT_FOLDER}/assets/fonts
+RUN gulp --environment ${environment} fonts
+COPY --chown=elife:elife assets/img/ ${PROJECT_FOLDER}/assets/img
+RUN gulp --environment ${environment} img
+
+COPY --chown=elife:elife assets/js/ ${PROJECT_FOLDER}/assets/js
+RUN gulp --environment ${environment} js
+
+COPY --chown=elife:elife source/ ${PROJECT_FOLDER}/source
+
+COPY --chown=elife:elife assets/sass ${PROJECT_FOLDER}/assets/sass
+RUN gulp --environment ${environment} generateStyles

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,13 +1,7 @@
 ARG image_tag=latest
-FROM elifesciences/pattern-library_assets:${image_tag} AS assets
-FROM elifesciences/pattern-library_node:${image_tag}
-
-ENV PROJECT_FOLDER=/srv/pattern-library
+FROM elifesciences/pattern-library_assets-builder:${image_tag}
 
 USER elife
 COPY --chown=elife:elife test/ ${PROJECT_FOLDER}/test
 COPY --chown=elife:elife test-selenium/ ${PROJECT_FOLDER}/test-selenium
 COPY --chown=elife:elife project_tests.sh smoke_tests.sh wdio.conf.js ${PROJECT_FOLDER}/
-COPY --from=assets \
-    --chown=elife:elife \
-    /srv/pattern-library/source/ ${PROJECT_FOLDER}/source

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,7 +1,13 @@
 ARG image_tag=latest
-FROM elifesciences/pattern-library_assets:${image_tag}
+FROM elifesciences/pattern-library_assets:${image_tag} AS assets
+FROM elifesciences/pattern-library_node:${image_tag}
+
+ENV PROJECT_FOLDER=/srv/pattern-library
 
 USER elife
 COPY --chown=elife:elife test/ ${PROJECT_FOLDER}/test
 COPY --chown=elife:elife test-selenium/ ${PROJECT_FOLDER}/test-selenium
 COPY --chown=elife:elife project_tests.sh smoke_tests.sh wdio.conf.js ${PROJECT_FOLDER}/
+COPY --from=assets \
+    --chown=elife:elife \
+    /srv/pattern-library/source/ ${PROJECT_FOLDER}/source

--- a/Dockerfile.node
+++ b/Dockerfile.node
@@ -1,0 +1,37 @@
+# Debian oldoldstable, support ends in May 2018
+# we need this for Ruby 1.9.x at the moment
+FROM node:6.13.1-wheezy
+
+# TODO: base image
+USER root
+RUN useradd -ms /bin/bash -G www-data elife && \
+    chown elife:elife /srv && \
+    mkdir /srv/bin && \
+    chown elife:elife /srv/bin && \
+    mkdir -p /var/www && \
+    chown www-data:www-data /var/www
+ENV PATH=/srv/bin:${PATH}
+# end base image
+
+# potentially base image
+RUN npm install -g gulp-cli
+# end potentially base image
+
+RUN apt-get update && apt-get install -y \
+    bzip2 \
+    g++ \
+    make \
+    ruby \
+    ruby-dev 
+
+RUN gem install compass
+
+USER elife
+ENV PROJECT_FOLDER=/srv/pattern-library
+RUN mkdir ${PROJECT_FOLDER}
+WORKDIR ${PROJECT_FOLDER}
+COPY --chown=elife:elife \
+    package.json \
+    npm-shrinkwrap.json \
+    ${PROJECT_FOLDER}/
+RUN npm install

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,12 @@
 version: '3'
 
 services:
+    assets-builder:
+        build:
+            context: .
+            dockerfile: Dockerfile.assets-builder
+        image: elifesciences/pattern-library_assets-builder:${IMAGE_TAG}
+        command: /bin/bash
     assets:
         build:
             context: .
@@ -11,7 +17,7 @@ services:
         image: elifesciences/pattern-library_assets:${IMAGE_TAG}
         command: /bin/sh
         depends_on:
-            - node
+            - assets-builder
     ui:
         build:
             context: .
@@ -32,16 +38,9 @@ services:
         image: elifesciences/pattern-library_ci:${IMAGE_TAG}
         command: /bin/bash
         depends_on:
-            - assets
-            - node
+            - assets-builder
             - ui
             - selenium
-    node:
-        build:
-            context: .
-            dockerfile: Dockerfile.node
-        image: elifesciences/pattern-library_node:${IMAGE_TAG}
-        command: /bin/bash
     selenium:
         build:
             context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
             args:
                 environment: ${ENVIRONMENT}
         image: elifesciences/pattern-library_assets:${IMAGE_TAG}
-        command: /bin/bash
+        command: /bin/sh
     ui:
         build:
             context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,11 @@ services:
             dockerfile: Dockerfile.assets
             args:
                 environment: ${ENVIRONMENT}
+                image_tag: ${IMAGE_TAG}
         image: elifesciences/pattern-library_assets:${IMAGE_TAG}
         command: /bin/sh
+        depends_on:
+            - node
     ui:
         build:
             context: .
@@ -30,8 +33,15 @@ services:
         command: /bin/bash
         depends_on:
             - assets
+            - node
             - ui
             - selenium
+    node:
+        build:
+            context: .
+            dockerfile: Dockerfile.node
+        image: elifesciences/pattern-library_node:${IMAGE_TAG}
+        command: /bin/bash
     selenium:
         build:
             context: .


### PR DESCRIPTION
This should reduce the size, as we don't need to distribute the tools required to build the assets.