### PR TITLE
ELPP-3500 Optimize browserify-tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ You should be good to go, open your browser and you will see the pattern lab.
 - install required npm packages with `npm install`
 - run `gulp` to build the css & js files.
 - then run `gulp watch` to watch for changes to files or do both in one fell swoop with `gulp && gulp watch` (the watch task on its own will not compile your assets until a file is changed).
-- run `gulp test --mocha-grep=something` to pass the `--grep` option to mocha and run a subset of tests.
+- run `gulp local:test:unit --mocha-grep=something` to pass the `--grep` option to mocha and run a subset of tests.
 - if generating files intended for website production, invoke with the production flag, like this: `gulp --environment production`. The minifies css & js files.
 
 ## 3. Generate PatternLab

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -177,7 +177,7 @@ gulp.task('fonts', () => {
  * Creates a sourcemap.
  ******************************************************************************/
 
-gulp.task('js', ['js:hint', 'js:cs', 'browserify-tests'], () => {
+gulp.task('js', ['js:hint', 'js:cs'], () => {
 
     return browserify('./assets/js/main.js', { debug: true })
           .transform(babel)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -233,7 +233,7 @@ gulp.task('browserify-tests', (done) => {
 });
 
 
-gulp.task('test', ['browserify-tests', 'js'], () => {
+gulp.task('local:test:unit', ['browserify-tests', 'js'], () => {
   return gulp.src('./test/*.html')
     .pipe(mochaPhantomjs({
       reporter: 'spec',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -245,6 +245,18 @@ gulp.task('test', ['browserify-tests', 'js'], () => {
     .pipe(reload());
 });
 
+gulp.task('test:unit', ['browserify-tests'], () => {
+  return gulp.src('./test/*.html')
+    .pipe(mochaPhantomjs({
+      reporter: 'spec',
+      mocha: {
+        grep: mocha_grep
+      },
+      'ignore-resource-errors': true
+    }))
+    .pipe(reload());
+});
+
 gulp.task('test:selenium', function() {
     return gulp.src('wdio.conf.js').pipe(webdriver());
 });

--- a/project_tests.sh
+++ b/project_tests.sh
@@ -2,7 +2,7 @@
 set -e
 
 echo "Running gulp unit test suite"
-gulp test
+gulp test:unit
 
 echo "Running Selenium test suite"
 gulp test:selenium


### PR DESCRIPTION
This command should not be needed in the main `js` task, as it can be run when tests are actually needed (`gulp test`).

Moreover, with a separate `test:unit` target to be run only in the `ci` container, we can run only test and skip the `js` task that has already been executed during the building of the `assets` image.