### PR TITLE
Fix image-based content header wrapping when narrow

### DIFF
--- a/assets/sass/patterns/organisms/content-header.scss
+++ b/assets/sass/patterns/organisms/content-header.scss
@@ -54,11 +54,10 @@
     height: #{($content-header-padding * 5.5)}px;
 
     .content-header--has-social-media-sharers & {
-      min-height: #{$content-header-padding * 7}px;
+      min-height: #{$content-header-padding * 8}px;
     }
 
     display: flex;
-    flex-wrap: wrap;
     flex-direction: column;
     align-items: center;
     align-content: center;
@@ -414,12 +413,24 @@ $iconlist: cc oa;
     @include margin(0, "bottom");
     display: none;
 
-    @media only all and (min-width: #{get-rem-from-px($bkpt-site--wide)}em) {
+    @media only all and (min-width: #{get-rem-from-px($bkpt-content-header--wide)}em) {
       display: block;
     }
 
     a {
       @include discreet-link($color-text--reverse, false);
+    }
+
+  }
+
+  .content-header--image.content-header--has-social-media-sharers & {
+
+    @media only all and (min-width: #{get-rem-from-px($bkpt-content-header--wide)}em) {
+      display: none;
+    }
+
+    @media only all and (min-width: #{get-rem-from-px($bkpt-content-header--extra-wide)}em) {
+      display: block;
     }
 
   }


### PR DESCRIPTION
Fixes a layout issue for an image-backed content header containing both an impact statement and social sharing icons. (Manifests on a Collection with a longer title). Impact statements in these content headers that were displayed when the screen width hits the `wide` breakpoint are now only displayed at the `x-wide` breakpoint.

