### PR TITLE
ELPP-3635: Increase Hypothesis load timeout to 20s

### DIFF
--- a/assets/js/components/HypothesisOpener.js
+++ b/assets/js/components/HypothesisOpener.js
@@ -53,7 +53,7 @@ module.exports = class HypothesisOpener {
       return;
     }
 
-    const maxWaitTime = 10000;
+    const maxWaitTime = 20000;
 
     const maxWaitTimer = this.window.setTimeout(this.handleTimerExpired.bind(this), maxWaitTime);
 


### PR DESCRIPTION
RUM from New Relic shows a number of timeouts of the Hypothesis client load. This PR doubles the time before the load is defined as timing out. New Relic should be monitored for a few days after deployment to observe how the timeout rate changes.