### PR TITLE
ELPP-3598 Remove non-ASCII characters from error pages

### DIFF
--- a/.ci/errors-ascii-chars
+++ b/.ci/errors-ascii-chars
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+echo "Checking for non-ASCII characters in error messages"
+echo "These messages end up in places with limitations like VCL"
+negated_ascii_range="[^\x00-\x7F]"
+matching=$(grep \
+    --color='auto' \
+    --perl-regexp "$negated_ascii_range" \
+    --line-number \
+    --recursive \
+    source/_patterns/00-atoms/errors/)
+if [ "$matching" != "" ]; then
+    echo "Non-ASCII characters found:"
+    echo "$matching"
+    exit 1
+fi

--- a/.ci/errors-ascii-chars
+++ b/.ci/errors-ascii-chars
@@ -15,3 +15,4 @@ if [ "$matching" != "" ]; then
     echo "$matching"
     exit 1
 fi
+exit 0

--- a/.ci/errors-ascii-chars
+++ b/.ci/errors-ascii-chars
@@ -5,7 +5,7 @@ echo "Checking for non-ASCII characters in error messages"
 echo "These messages end up in places with limitations like VCL"
 negated_ascii_range="[^\x00-\x7F]"
 matching=$(grep \
-    --color='auto' \
+    --color='yes' \
     --perl-regexp "$negated_ascii_range" \
     --line-number \
     --recursive \

--- a/.ci/errors-ascii-chars
+++ b/.ci/errors-ascii-chars
@@ -9,7 +9,7 @@ matching=$(grep \
     --perl-regexp "$negated_ascii_range" \
     --line-number \
     --recursive \
-    source/_patterns/00-atoms/errors/)
+    source/_patterns/00-atoms/errors/ || true)
 if [ "$matching" != "" ]; then
     echo "Non-ASCII characters found:"
     echo "$matching"

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -2,6 +2,7 @@ ARG image_tag=latest
 FROM elifesciences/pattern-library_assets-builder:${image_tag}
 
 USER elife
+COPY --chown=elife:elife .ci/ ${PROJECT_FOLDER}/.ci
 COPY --chown=elife:elife test/ ${PROJECT_FOLDER}/test
 COPY --chown=elife:elife test-selenium/ ${PROJECT_FOLDER}/test-selenium
 COPY --chown=elife:elife project_tests.sh smoke_tests.sh wdio.conf.js ${PROJECT_FOLDER}/

--- a/project_tests.sh
+++ b/project_tests.sh
@@ -6,3 +6,6 @@ gulp test:unit
 
 echo "Running Selenium test suite"
 gulp test:selenium
+
+echo "Static checks"
+.ci/errors-ascii-chars

--- a/source/_patterns/00-atoms/errors/client-error.mustache
+++ b/source/_patterns/00-atoms/errors/client-error.mustache
@@ -10,7 +10,7 @@
 
     <h1 class="error__title">Say what?</h1>
 
-    <p>Your browser sent us something unexpected.<br>’vWe've logged the problem and will look into it.</p>
+    <p>Your browser sent us something unexpected.<br>We've logged the problem and will look into it.</p>
 
     {{#button}}
         {{> atoms-button }}

--- a/source/_patterns/00-atoms/errors/client-error.mustache
+++ b/source/_patterns/00-atoms/errors/client-error.mustache
@@ -10,7 +10,7 @@
 
     <h1 class="error__title">Say what?</h1>
 
-    <p>Your browser sent us something unexpected.<br>We’ve logged the problem and will look into it.</p>
+    <p>Your browser sent us something unexpected.<br>’vWe've logged the problem and will look into it.</p>
 
     {{#button}}
         {{> atoms-button }}

--- a/source/_patterns/00-atoms/errors/client-error.mustache
+++ b/source/_patterns/00-atoms/errors/client-error.mustache
@@ -10,7 +10,7 @@
 
     <h1 class="error__title">Say what?</h1>
 
-    <p>Your browser sent us something unexpected.<br>We've logged the problem and will look into it.</p>
+    <p>Your browser sent us something unexpected.<br>We&#x2019;ve logged the problem and will look into it.</p>
 
     {{#button}}
         {{> atoms-button }}

--- a/source/_patterns/00-atoms/errors/server-error.mustache
+++ b/source/_patterns/00-atoms/errors/server-error.mustache
@@ -10,7 +10,7 @@
 
     <h1 class="error__title">Kabooooooom!</h1>
 
-    <p>Something has gone seriously wrong.<br>We've logged the problem and will look into it.</p>
+    <p>Something has gone seriously wrong.<br>We’ve logged the problem and will look into it.</p>
 
     {{#button}}
         {{> atoms-button }}

--- a/source/_patterns/00-atoms/errors/server-error.mustache
+++ b/source/_patterns/00-atoms/errors/server-error.mustache
@@ -10,7 +10,7 @@
 
     <h1 class="error__title">Kabooooooom!</h1>
 
-    <p>Something has gone seriously wrong.<br>We've logged the problem and will look into it.</p>
+    <p>Something has gone seriously wrong.<br>We&#x2019;ve logged the problem and will look into it.</p>
 
     {{#button}}
         {{> atoms-button }}

--- a/source/_patterns/00-atoms/errors/server-error.mustache
+++ b/source/_patterns/00-atoms/errors/server-error.mustache
@@ -10,7 +10,7 @@
 
     <h1 class="error__title">Kabooooooom!</h1>
 
-    <p>Something has gone seriously wrong.<br>We’ve logged the problem and will look into it.</p>
+    <p>Something has gone seriously wrong.<br>We've logged the problem and will look into it.</p>
 
     {{#button}}
         {{> atoms-button }}

--- a/source/_patterns/00-atoms/errors/service-unavailable.mustache
+++ b/source/_patterns/00-atoms/errors/service-unavailable.mustache
@@ -10,7 +10,7 @@
 
     <h1 class="error__title">Back soon</h1>
 
-    <p>We’re carrying out planned maintenance on this page.</p>
+    <p>We're carrying out planned maintenance on this page.</p>
 
     {{#button}}
         {{> atoms-button }}

--- a/source/_patterns/00-atoms/errors/service-unavailable.mustache
+++ b/source/_patterns/00-atoms/errors/service-unavailable.mustache
@@ -10,7 +10,7 @@
 
     <h1 class="error__title">Back soon</h1>
 
-    <p>We're carrying out planned maintenance on this page.</p>
+    <p>We&#x2019;re carrying out planned maintenance on this page.</p>
 
     {{#button}}
         {{> atoms-button }}


### PR DESCRIPTION
Error pages and up in places like Fastly's VCL configuration files, where only ASCII characters are supported.

The right single quotation mark are outside of the 0x00-0x7F ASCII range. I'm no typographer but this character does not seem correct in this context. I've found no other non-ASCII characters being used (no emojis in error pages :pensive:).

The additional check quickly greps for any non-ASCII character in that folder. I've put it into `.ci` as that is a standard being adopted across projects to put checks to run in parallel.

In future use cases, non-ASCII characters can still be supported simply by escaping them as HTML entities: `&#8217;`|`&#x2019;`|`&rsquo;`.