### PR TITLE
Increase Hypothesis loading timeout to 1 minute

### DIFF
--- a/assets/js/components/HypothesisOpener.js
+++ b/assets/js/components/HypothesisOpener.js
@@ -53,7 +53,7 @@ module.exports = class HypothesisOpener {
       return;
     }
 
-    const maxWaitTime = 20000;
+    const maxWaitTime = 60000;
 
     const maxWaitTimer = this.window.setTimeout(this.handleTimerExpired.bind(this), maxWaitTime);
 


### PR DESCRIPTION
RUM still indicates quite a lot of Hypothesis client load timeouts. Increasing the timeout threshold from 20s to 60s to zap most of these.