### PR TITLE
ELPP-3703: Improve the accessibility of discovering the js-based search interface

### DIFF
--- a/assets/sass/patterns/organisms/site-header.scss
+++ b/assets/sass/patterns/organisms/site-header.scss
@@ -10,8 +10,13 @@
     background-color: #fff;
     display: none;
 
+    &.search-box--js:not(.search-box--shown) {
+      visibility: hidden;
+    }
+
     &.search-box--js {
       display: block;
+      visibility: visible;
       position: absolute;
       top: -20px;
       transition: transform 150ms;

--- a/assets/sass/patterns/organisms/site-header.scss
+++ b/assets/sass/patterns/organisms/site-header.scss
@@ -10,10 +10,6 @@
     background-color: #fff;
     display: none;
 
-    &.search-box--js:not(.search-box--shown) {
-      visibility: hidden;
-    }
-
     &.search-box--js {
       display: block;
       visibility: visible;
@@ -22,6 +18,12 @@
       transition: transform 150ms;
       width: 100%;
       z-index: 5;
+
+      // Justified breach of the css selector 3-clause-rule, as this controls different states of the same element
+      &:not(.search-box--shown) {
+        visibility: hidden;
+      }
+
     }
   }
 

--- a/source/_patterns/01-molecules/navigation/site-header-nav-bar~primary.json
+++ b/source/_patterns/01-molecules/navigation/site-header-nav-bar~primary.json
@@ -37,7 +37,7 @@
     },
 
     {
-      "text": "Search",
+      "text": "Search the eLife site",
       "rel": "search",
       "classes": "nav-primary__item nav-primary__item--search",
       "textClasses": "visuallyhidden",
@@ -48,7 +48,7 @@
         "srcset": "../../assets/img/patterns/molecules/nav-primary-search-ic_2x.png 2x, ../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png 1x",
         "defaultPath": "../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png",
         "classes": "",
-        "altText": "Search icon"
+        "altText": ""
       },
         "sources": [
           {

--- a/source/_patterns/02-organisms/components/filter-panel.json
+++ b/source/_patterns/02-organisms/components/filter-panel.json
@@ -29,7 +29,7 @@
     }
   ],
   "button": {
-    "text": "Search",
+    "text": "Search the eLife site",
     "classes": "button--default",
     "type": "submit",
     "name": "button"

--- a/source/_patterns/02-organisms/global/site-header.json
+++ b/source/_patterns/02-organisms/global/site-header.json
@@ -39,7 +39,7 @@
       },
 
       {
-        "text": "Search",
+        "text": "Search the eLife site",
         "rel": "search",
         "classes": "nav-primary__item nav-primary__item--search",
         "textClasses": "visuallyhidden",
@@ -50,7 +50,7 @@
             "srcset": "../../assets/img/patterns/molecules/nav-primary-search-ic_2x.png 2x, ../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png 1x",
             "defaultPath": "../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png",
             "classes": "",
-            "altText": "Search icon"
+            "altText": ""
           },
           "sources": [
             {

--- a/source/_patterns/02-organisms/global/site-header~logged-in.json
+++ b/source/_patterns/02-organisms/global/site-header~logged-in.json
@@ -39,7 +39,7 @@
       },
 
       {
-        "text": "Search",
+        "text": "Search the eLife site",
         "rel": "search",
         "classes": "nav-primary__item nav-primary__item--search",
         "textClasses": "visuallyhidden",
@@ -50,7 +50,7 @@
             "srcset": "../../assets/img/patterns/molecules/nav-primary-search-ic_2x.png 2x, ../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png 1x",
             "defaultPath": "../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png",
             "classes": "",
-            "altText": "Search icon"
+            "altText": ""
           },
           "sources": [
             {

--- a/source/_patterns/04-pages/about-elife~logged-in.json
+++ b/source/_patterns/04-pages/about-elife~logged-in.json
@@ -40,7 +40,7 @@
         },
 
         {
-          "text": "Search",
+          "text": "Search the eLife site",
           "rel": "search",
           "classes": "nav-primary__item nav-primary__item--search",
           "textClasses": "visuallyhidden",
@@ -51,7 +51,7 @@
               "srcset": "../../assets/img/patterns/molecules/nav-primary-search-ic_2x.png 48w, ../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png 24w",
               "defaultPath": "../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png",
               "classes": "",
-              "altText": "Search icon"
+              "altText": ""
             },
             "sources": [
               {

--- a/source/_patterns/04-pages/about-people.json
+++ b/source/_patterns/04-pages/about-people.json
@@ -40,7 +40,7 @@
         },
 
         {
-          "text": "Search",
+          "text": "Search the eLife site",
           "rel": "search",
           "classes": "nav-primary__item nav-primary__item--search",
           "textClasses": "visuallyhidden",
@@ -51,7 +51,7 @@
               "srcset": "../../assets/img/patterns/molecules/nav-primary-search-ic_2x.png 48w, ../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png 24w",
               "defaultPath": "../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png",
               "classes": "",
-              "altText": "Search icon"
+              "altText": ""
             },
             "sources": [
               {

--- a/source/_patterns/04-pages/archive-year.json
+++ b/source/_patterns/04-pages/archive-year.json
@@ -40,7 +40,7 @@
         },
 
         {
-          "text": "Search",
+          "text": "Search the eLife site",
           "rel": "search",
           "classes": "nav-primary__item nav-primary__item--search",
           "textClasses": "visuallyhidden",
@@ -51,7 +51,7 @@
               "srcset": "../../assets/img/patterns/molecules/nav-primary-search-ic_2x.png 48w, ../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png 24w",
               "defaultPath": "../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png",
               "classes": "",
-              "altText": "Search icon"
+              "altText": ""
             },
             "sources": [
               {

--- a/source/_patterns/04-pages/article--charts.json
+++ b/source/_patterns/04-pages/article--charts.json
@@ -40,7 +40,7 @@
         },
 
         {
-          "text": "Search",
+          "text": "Search the eLife site",
           "rel": "search",
           "classes": "nav-primary__item nav-primary__item--search",
           "textClasses": "visuallyhidden",
@@ -51,7 +51,7 @@
               "srcset": "../../assets/img/patterns/molecules/nav-primary-search-ic_2x.png 48w, ../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png 24w",
               "defaultPath": "../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png",
               "classes": "",
-              "altText": "Search icon"
+              "altText": ""
             },
             "sources": [
               {

--- a/source/_patterns/04-pages/article--figures.json
+++ b/source/_patterns/04-pages/article--figures.json
@@ -39,7 +39,7 @@
         },
 
         {
-          "text": "Search",
+          "text": "Search the eLife site",
           "rel": "search",
           "classes": "nav-primary__item nav-primary__item--search",
           "textClasses": "visuallyhidden",
@@ -50,7 +50,7 @@
               "srcset": "../../assets/img/patterns/molecules/nav-primary-search-ic_2x.png 2x, ../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png 1x",
               "defaultPath": "../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png",
               "classes": "",
-              "altText": "Search icon"
+              "altText": ""
             },
             "sources": [
               {

--- a/source/_patterns/04-pages/article--magazine.json
+++ b/source/_patterns/04-pages/article--magazine.json
@@ -40,7 +40,7 @@
         },
 
         {
-          "text": "Search",
+          "text": "Search the eLife site",
           "rel": "search",
           "classes": "nav-primary__item nav-primary__item--search",
           "textClasses": "visuallyhidden",
@@ -51,7 +51,7 @@
               "srcset": "../../assets/img/patterns/molecules/nav-primary-search-ic_2x.png 48w, ../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png 24w",
               "defaultPath": "../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png",
               "classes": "",
-              "altText": "Search icon"
+              "altText": ""
             },
             "sources": [
               {

--- a/source/_patterns/04-pages/article--press-pack~has-related-has-jumplinks.json
+++ b/source/_patterns/04-pages/article--press-pack~has-related-has-jumplinks.json
@@ -42,7 +42,7 @@
         },
 
         {
-          "text": "Search",
+          "text": "Search the eLife site",
           "rel": "search",
           "classes": "nav-primary__item nav-primary__item--search",
           "textClasses": "visuallyhidden",
@@ -53,7 +53,7 @@
               "srcset": "../../assets/img/patterns/molecules/nav-primary-search-ic_2x.png 48w, ../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png 24w",
               "defaultPath": "../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png",
               "classes": "",
-              "altText": "Search icon"
+              "altText": ""
             },
             "sources": [
               {

--- a/source/_patterns/04-pages/article--press-pack~has-related-no-jumplinks.json
+++ b/source/_patterns/04-pages/article--press-pack~has-related-no-jumplinks.json
@@ -42,7 +42,7 @@
         },
 
         {
-          "text": "Search",
+          "text": "Search the eLife site",
           "rel": "search",
           "classes": "nav-primary__item nav-primary__item--search",
           "textClasses": "visuallyhidden",
@@ -53,7 +53,7 @@
               "srcset": "../../assets/img/patterns/molecules/nav-primary-search-ic_2x.png 48w, ../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png 24w",
               "defaultPath": "../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png",
               "classes": "",
-              "altText": "Search icon"
+              "altText": ""
             },
             "sources": [
               {

--- a/source/_patterns/04-pages/article--press-pack~without-related-nor-jump-links.json
+++ b/source/_patterns/04-pages/article--press-pack~without-related-nor-jump-links.json
@@ -40,7 +40,7 @@
         },
 
         {
-          "text": "Search",
+          "text": "Search the eLife site",
           "rel": "search",
           "classes": "nav-primary__item nav-primary__item--search",
           "textClasses": "visuallyhidden",
@@ -51,7 +51,7 @@
               "srcset": "../../assets/img/patterns/molecules/nav-primary-search-ic_2x.png 48w, ../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png 24w",
               "defaultPath": "../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png",
               "classes": "",
-              "altText": "Search icon"
+              "altText": ""
             },
             "sources": [
               {

--- a/source/_patterns/04-pages/article--press-pack~without-related.json
+++ b/source/_patterns/04-pages/article--press-pack~without-related.json
@@ -41,7 +41,7 @@
         },
 
         {
-          "text": "Search",
+          "text": "Search the eLife site",
           "rel": "search",
           "classes": "nav-primary__item nav-primary__item--search",
           "textClasses": "visuallyhidden",
@@ -52,7 +52,7 @@
               "srcset": "../../assets/img/patterns/molecules/nav-primary-search-ic_2x.png 48w, ../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png 24w",
               "defaultPath": "../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png",
               "classes": "",
-              "altText": "Search icon"
+              "altText": ""
             },
             "sources": [
               {

--- a/source/_patterns/04-pages/article--research.json
+++ b/source/_patterns/04-pages/article--research.json
@@ -41,7 +41,7 @@
         },
 
         {
-          "text": "Search",
+          "text": "Search the eLife site",
           "rel": "search",
           "classes": "nav-primary__item nav-primary__item--search",
           "textClasses": "visuallyhidden",
@@ -52,7 +52,7 @@
               "srcset": "../../assets/img/patterns/molecules/nav-primary-search-ic_2x.png 48w, ../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png 24w",
               "defaultPath": "../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png",
               "classes": "",
-              "altText": "Search icon"
+              "altText": ""
             },
             "sources": [
               {

--- a/source/_patterns/04-pages/article--research~with-further-reading-all-related.json
+++ b/source/_patterns/04-pages/article--research~with-further-reading-all-related.json
@@ -41,7 +41,7 @@
         },
 
         {
-          "text": "Search",
+          "text": "Search the eLife site",
           "rel": "search",
           "classes": "nav-primary__item nav-primary__item--search",
           "textClasses": "visuallyhidden",
@@ -52,7 +52,7 @@
               "srcset": "../../assets/img/patterns/molecules/nav-primary-search-ic_2x.png 48w, ../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png 24w",
               "defaultPath": "../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png",
               "classes": "",
-              "altText": "Search icon"
+              "altText": ""
             },
             "sources": [
               {

--- a/source/_patterns/04-pages/collection.json
+++ b/source/_patterns/04-pages/collection.json
@@ -40,7 +40,7 @@
         },
 
         {
-          "text": "Search",
+          "text": "Search the eLife site",
           "rel": "search",
           "classes": "nav-primary__item nav-primary__item--search",
           "textClasses": "visuallyhidden",
@@ -51,7 +51,7 @@
               "srcset": "../../assets/img/patterns/molecules/nav-primary-search-ic_2x.png 48w, ../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png 24w",
               "defaultPath": "../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png",
               "classes": "",
-              "altText": "Search icon"
+              "altText": ""
             },
             "sources": [
               {

--- a/source/_patterns/04-pages/home.json
+++ b/source/_patterns/04-pages/home.json
@@ -40,7 +40,7 @@
         },
 
         {
-          "text": "Search",
+          "text": "Search the eLife site",
           "rel": "search",
           "classes": "nav-primary__item nav-primary__item--search",
           "textClasses": "visuallyhidden",
@@ -51,7 +51,7 @@
               "srcset": "../../assets/img/patterns/molecules/nav-primary-search-ic_2x.png 48w, ../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png 24w",
               "defaultPath": "../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png",
               "classes": "",
-              "altText": "Search icon"
+              "altText": ""
             },
             "sources": [
               {

--- a/source/_patterns/04-pages/inside-elife-article.json
+++ b/source/_patterns/04-pages/inside-elife-article.json
@@ -40,7 +40,7 @@
         },
 
         {
-          "text": "Search",
+          "text": "Search the eLife site",
           "rel": "search",
           "classes": "nav-primary__item nav-primary__item--search",
           "textClasses": "visuallyhidden",
@@ -51,7 +51,7 @@
               "srcset": "../../assets/img/patterns/molecules/nav-primary-search-ic_2x.png 48w, ../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png 24w",
               "defaultPath": "../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png",
               "classes": "",
-              "altText": "Search icon"
+              "altText": ""
             },
             "sources": [
               {

--- a/source/_patterns/04-pages/labs.json
+++ b/source/_patterns/04-pages/labs.json
@@ -40,7 +40,7 @@
         },
 
         {
-          "text": "Search",
+          "text": "Search the eLife site",
           "rel": "search",
           "classes": "nav-primary__item nav-primary__item--search",
           "textClasses": "visuallyhidden",
@@ -51,7 +51,7 @@
               "srcset": "../../assets/img/patterns/molecules/nav-primary-search-ic_2x.png 48w, ../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png 24w",
               "defaultPath": "../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png",
               "classes": "",
-              "altText": "Search icon"
+              "altText": ""
             },
             "sources": [
               {

--- a/source/_patterns/04-pages/magazine.json
+++ b/source/_patterns/04-pages/magazine.json
@@ -40,7 +40,7 @@
         },
 
         {
-          "text": "Search",
+          "text": "Search the eLife site",
           "rel": "search",
           "classes": "nav-primary__item nav-primary__item--search",
           "textClasses": "visuallyhidden",
@@ -51,7 +51,7 @@
               "srcset": "../../assets/img/patterns/molecules/nav-primary-search-ic_2x.png 48w, ../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png 24w",
               "defaultPath": "../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png",
               "classes": "",
-              "altText": "Search icon"
+              "altText": ""
             },
             "sources": [
               {

--- a/source/_patterns/04-pages/msa.json
+++ b/source/_patterns/04-pages/msa.json
@@ -40,7 +40,7 @@
         },
 
         {
-          "text": "Search",
+          "text": "Search the eLife site",
           "rel": "search",
           "classes": "nav-primary__item nav-primary__item--search",
           "textClasses": "visuallyhidden",
@@ -51,7 +51,7 @@
               "srcset": "../../assets/img/patterns/molecules/nav-primary-search-ic_2x.png 48w, ../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png 24w",
               "defaultPath": "../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png",
               "classes": "",
-              "altText": "Search icon"
+              "altText": ""
             },
             "sources": [
               {

--- a/source/_patterns/04-pages/page-not-found.json
+++ b/source/_patterns/04-pages/page-not-found.json
@@ -40,7 +40,7 @@
         },
 
         {
-          "text": "Search",
+          "text": "Search the eLife site",
           "rel": "search",
           "classes": "nav-primary__item nav-primary__item--search",
           "textClasses": "visuallyhidden",
@@ -51,7 +51,7 @@
               "srcset": "../../assets/img/patterns/molecules/nav-primary-search-ic_2x.png 48w, ../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png 24w",
               "defaultPath": "../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png",
               "classes": "",
-              "altText": "Search icon"
+              "altText": ""
             },
             "sources": [
               {

--- a/source/_patterns/04-pages/podcast.json
+++ b/source/_patterns/04-pages/podcast.json
@@ -40,7 +40,7 @@
         },
 
         {
-          "text": "Search",
+          "text": "Search the eLife site",
           "rel": "search",
           "classes": "nav-primary__item nav-primary__item--search",
           "textClasses": "visuallyhidden",
@@ -51,7 +51,7 @@
               "srcset": "../../assets/img/patterns/molecules/nav-primary-search-ic_2x.png 48w, ../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png 24w",
               "defaultPath": "../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png",
               "classes": "",
-              "altText": "Search icon"
+              "altText": ""
             },
             "sources": [
               {

--- a/source/_patterns/04-pages/podcasts.json
+++ b/source/_patterns/04-pages/podcasts.json
@@ -40,7 +40,7 @@
         },
 
         {
-          "text": "Search",
+          "text": "Search the eLife site",
           "rel": "search",
           "classes": "nav-primary__item nav-primary__item--search",
           "textClasses": "visuallyhidden",
@@ -51,7 +51,7 @@
               "srcset": "../../assets/img/patterns/molecules/nav-primary-search-ic_2x.png 48w, ../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png 24w",
               "defaultPath": "../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png",
               "classes": "",
-              "altText": "Search icon"
+              "altText": ""
             },
             "sources": [
               {

--- a/source/_patterns/04-pages/profile.json
+++ b/source/_patterns/04-pages/profile.json
@@ -40,7 +40,7 @@
         },
 
         {
-          "text": "Search",
+          "text": "Search the eLife site",
           "rel": "search",
           "classes": "nav-primary__item nav-primary__item--search",
           "textClasses": "visuallyhidden",
@@ -51,7 +51,7 @@
               "srcset": "../../assets/img/patterns/molecules/nav-primary-search-ic_2x.png 48w, ../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png 24w",
               "defaultPath": "../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png",
               "classes": "",
-              "altText": "Search icon"
+              "altText": ""
             },
             "sources": [
               {

--- a/source/_patterns/04-pages/search.json
+++ b/source/_patterns/04-pages/search.json
@@ -40,7 +40,7 @@
         },
 
         {
-          "text": "Search",
+          "text": "Search the eLife site",
           "rel": "search",
           "classes": "nav-primary__item nav-primary__item--search",
           "textClasses": "visuallyhidden",
@@ -51,7 +51,7 @@
               "srcset": "../../assets/img/patterns/molecules/nav-primary-search-ic_2x.png 48w, ../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png 24w",
               "defaultPath": "../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png",
               "classes": "",
-              "altText": "Search icon"
+              "altText": ""
             },
             "sources": [
               {

--- a/source/_patterns/04-pages/subjects.json
+++ b/source/_patterns/04-pages/subjects.json
@@ -40,7 +40,7 @@
         },
 
         {
-          "text": "Search",
+          "text": "Search the eLife site",
           "rel": "search",
           "classes": "nav-primary__item nav-primary__item--search",
           "textClasses": "visuallyhidden",
@@ -51,7 +51,7 @@
               "srcset": "../../assets/img/patterns/molecules/nav-primary-search-ic_2x.png 48w, ../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png 24w",
               "defaultPath": "../../assets/img/patterns/molecules/nav-primary-search-ic_1x.png",
               "classes": "",
-              "altText": "Search icon"
+              "altText": ""
             },
             "sources": [
               {


### PR DESCRIPTION
In the global site header:
- Only expose the js-backed search interface to AT when the control is activated
- Improve annoucement of search control in site header