### PR TITLE
Style as discreet: links in articles' unordered, non-reference lists

### DIFF
--- a/assets/sass/_normalize-overrides.scss
+++ b/assets/sass/_normalize-overrides.scss
@@ -61,6 +61,10 @@ p a:not(.additional-asset__link--download):not(.asset-viewer-inline__download_al
   @include discreet-link();
 }
 
+.article-section__body ul:not(.reference__abstracts) a {
+  @include discreet-link();
+}
+
 b,
 strong {
   font-weight: bold;


### PR DESCRIPTION
Styling of discreet links is of necessity a fairly blunt instrument. This change has been eyeball tested on a copy of the site and there don't appear to be links styles as `discreet-link` where there shouldn't be. If any are reported, we can tight up the selector.