### PR TITLE
ELPP-3736: Remove individual css

### DIFF
--- a/Dockerfile.assets-builder
+++ b/Dockerfile.assets-builder
@@ -20,15 +20,11 @@ RUN npm install -g gulp-cli
 RUN apt-get update && apt-get install -y \
     bzip2 \
     g++ \
-    make \
-    ruby \
-    ruby-dev 
-
-RUN gem install compass
+    make
 
 USER elife
 ENV PROJECT_FOLDER=/srv/pattern-library
-# for simplicity, also set right permissions to test folder 
+# for simplicity, also set right permissions to test folder
 # (and any volume mounted on it) in case assets-builder
 # is used locally to run gulp tasks
 RUN mkdir ${PROJECT_FOLDER} && \
@@ -46,7 +42,6 @@ COPY --chown=elife:elife \
     .jscsrc \
     .jshintrc \
     .stylelintrc \
-    config.rb \
     gulpfile.js \
     ${PROJECT_FOLDER}/
 
@@ -61,4 +56,4 @@ RUN gulp --environment ${environment} js
 COPY --chown=elife:elife source/ ${PROJECT_FOLDER}/source
 
 COPY --chown=elife:elife assets/sass ${PROJECT_FOLDER}/assets/sass
-RUN gulp --environment ${environment} generateStyles
+RUN gulp --environment ${environment} generateCss

--- a/README.md
+++ b/README.md
@@ -14,9 +14,6 @@ You'll need:
 
  - PHP (for Patternlab)
  - nodejs (for gulp)
- - ruby (to handle the `compass` gem that underpins `gulp-compass` (see https://www.npmjs.com/package/gulp-compass).
-
-Then install compass: `gem install compass`
 
 ## 2. Automatic setup
 From the root directory run

--- a/bin/validate
+++ b/bin/validate
@@ -23,17 +23,11 @@ $jsonSchema = $refResolver->resolve('file://' . __DIR__ . '/../extras/json-schem
 $exit = 0;
 
 foreach ($finder as $file) {
-    try {
-        $yaml = Yaml::parse($file->getContents());
-        $yaml = resolveJsonReferences($yaml, $file);
-        $yaml = Yaml::dump($yaml, 100);
-        $yaml = str_replace(' {  }', ' []', $yaml);
-        $yaml = Yaml::parse($yaml, true, false, true);
-    }
-    catch (\Exception $e) {
-        print $e->getMessage() . PHP_EOL;
-        exit;
-    }
+    $yaml = Yaml::parse($file->getContents());
+    $yaml = resolveJsonReferences($yaml, $file);
+    $yaml = Yaml::dump($yaml, 100);
+    $yaml = str_replace(' {  }', ' []', $yaml);
+    $yaml = Yaml::parse($yaml, true, false, true);
 
     $validator->reset();
     $validator->check($yaml, $jsonSchema);
@@ -101,11 +95,7 @@ function resolveJsonReferences(array $json, SplFileInfo $file)
                 $json = Yaml::parse(file_get_contents($referenced->getRealPath()));
             }
 
-            if (isset($parts[1])) {
-                $json = (new Pointer(json_encode($json)))->get($parts[1]);
-            }
-
-            return resolveJsonReferences($json, $referenced);
+            return resolveJsonReferences((new Pointer(json_encode($json)))->get($parts[1]), $referenced);
         }
     }
 

--- a/bin/validate
+++ b/bin/validate
@@ -101,9 +101,11 @@ function resolveJsonReferences(array $json, SplFileInfo $file)
                 $json = Yaml::parse(file_get_contents($referenced->getRealPath()));
             }
 
-            $pointer = new Pointer(json_encode($json));
+            if (isset($parts[1])) {
+                $json = (new Pointer(json_encode($json)))->get($parts[1]);
+            }
 
-            return resolveJsonReferences($pointer->get($parts[1]), $referenced);
+            return resolveJsonReferences($json, $referenced);
         }
     }
 

--- a/bin/validate
+++ b/bin/validate
@@ -36,7 +36,7 @@ foreach ($finder as $file) {
     }
 
     $validator->reset();
-    $validator->check($yaml->schema, $jsonSchema);
+    $validator->check($yaml, $jsonSchema);
     if (!$validator->isValid()) {
         $exit = 1;
         $message = 'Error in schema: ' . $file->getFilename() . PHP_EOL;
@@ -57,7 +57,7 @@ foreach ($finder as $file) {
 
     foreach ($jsonFinder as $json) {
         $validator->reset();
-        $validator->check(json_decode(file_get_contents($json)), $yaml->schema);
+        $validator->check(json_decode(file_get_contents($json)), $yaml);
         if (!$validator->isValid()) {
             $exit = 1;
             $message = 'Error: ' . $json->getFilename() . PHP_EOL;

--- a/bin/validate
+++ b/bin/validate
@@ -95,7 +95,11 @@ function resolveJsonReferences(array $json, SplFileInfo $file)
                 $json = Yaml::parse(file_get_contents($referenced->getRealPath()));
             }
 
-            return resolveJsonReferences((new Pointer(json_encode($json)))->get($parts[1]), $referenced);
+            if (isset($parts[1])) {
+                $json = (new Pointer(json_encode($json)))->get($parts[1]);
+            }
+
+            return resolveJsonReferences($json, $referenced);
         }
     }
 

--- a/config.rb
+++ b/config.rb
@@ -1,1 +1,0 @@
-Encoding.default_external = "utf-8"

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,7 +10,6 @@ const babel             = require('babelify');
 const browserify        = require('browserify');
 const browserSync       = require('browser-sync');
 const buffer            = require('vinyl-buffer');
-const compass           = require('gulp-compass');
 const concat            = require('gulp-concat');
 const del               = require('del');
 const es                = require('event-stream');
@@ -73,35 +72,6 @@ gulp.task('echo', [], () => {
   console.log(options);
 });
 
-gulp.task('generateStyles', ['generateAllStyles', 'generateIndividualStyles'], () => {
-  return del(['source/assets/css/tmp']);
-});
-
-gulp.task('generateIndividualStyles', ['buildStyleFiles'], () => {
-  return gulp.src(['source/assets/css/tmp/**/*.css', 'source/assets/css/tmp/**/*.map'])
-      .pipe(rename({ dirname: '' }))
-      .pipe(gulp.dest('source/assets/css'));
-
-});
-
-gulp.task('buildStyleFiles', ['sass:lint'], () => {
-
-  return gulp.src(['assets/sass/base.scss', 'assets/sass/patterns/**/*.scss'])
-    .pipe(compass(
-      {
-        config_file: 'config.rb',
-        css: 'source/assets/css/tmp',
-        sass: 'assets/sass',
-        sourcemap: true,
-        style: environment === 'production' ? 'compressed' : 'expanded'
-      }
-    ))
-    .pipe(gulp.dest('source/assets/css/tmp'));
-
-  }
-);
-
-
  /******************************************************************************
   * CSS pre-processing task
   *
@@ -112,8 +82,7 @@ gulp.task('buildStyleFiles', ['sass:lint'], () => {
   * Auto-prefixes properties as required.
   ******************************************************************************/
 
-gulp.task('generateAllStyles', ['sass:lint'], () => {
-
+gulp.task('generateCss', ['sass:lint'], () => {
   let options = environment === 'production' ? {outputStyle: 'compressed'} : null;
 
   return gulp.src('assets/sass/build.scss')
@@ -300,7 +269,7 @@ gulp.task('test:selenium:local', function() {
 // Watchers
 
 gulp.task('sass:watch', () => {
-  gulp.watch('assets/sass/**/*', ['generateStyles']);
+  gulp.watch('assets/sass/**/*', ['generateCss']);
 });
 
 gulp.task('img:watch', () => {
@@ -325,12 +294,12 @@ gulp.task('watch', ['sass:watch', 'img:watch', 'js:watch', 'fonts:watch'], () =>
   // no better standalone solution without Gulp 4.x
   // https://stackoverflow.com/questions/22824546/how-to-run-gulp-tasks-sequentially-one-after-the-other/38818657#38818657
   gulp.on('task_stop', function (event) {
-    if (['generateStyles', 'img', 'fonts', 'js'].indexOf(event.task) != -1) {
+    if (['generateCss', 'img', 'fonts', 'js'].indexOf(event.task) != -1) {
       gulp.start('extractAssets');
     }
   });
 });
-gulp.task('default', ['generateStyles', 'img', 'fonts', 'js']);
+gulp.task('default', ['generateCss', 'img', 'fonts', 'js']);
 
 /******************************************************************************
  * Used for local testing

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3550,28 +3550,6 @@
       "from": "gulp-autoprefixer@>=3.1.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/gulp-autoprefixer/-/gulp-autoprefixer-3.1.1.tgz"
     },
-    "gulp-compass": {
-      "version": "2.1.0",
-      "from": "gulp-compass@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/gulp-compass/-/gulp-compass-2.1.0.tgz",
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "from": "isarray@0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
-        },
-        "through2": {
-          "version": "0.6.5",
-          "from": "through2@>=0.6.5 <0.7.0",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz"
-        }
-      }
-    },
     "gulp-concat": {
       "version": "2.6.1",
       "from": "gulp-concat@>=2.6.1 <3.0.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "glob": "^7.0.3",
     "gulp": "^3.9.1",
     "gulp-autoprefixer": "^3.1.0",
-    "gulp-compass": "^2.1.0",
     "gulp-concat": "^2.6.1",
     "gulp-imagemin": "^2.4.0",
     "gulp-jscs": "^3.0.2",

--- a/source/_patterns/00-atoms/components/author-details.yaml
+++ b/source/_patterns/00-atoms/components/author-details.yaml
@@ -35,7 +35,7 @@ properties:
             required:
               - value
   orcid:
-    $ref: orcid.yaml#/schema
+    $ref: orcid.yaml
   groups:
     type: array
     items:

--- a/source/_patterns/00-atoms/components/author-details.yaml
+++ b/source/_patterns/00-atoms/components/author-details.yaml
@@ -1,73 +1,72 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    authorId:
-      type: string
-      minLength: 1
-    name:
-      type: string
-      minLength: 1
-    details:
-      type: array
-      items:
-        type: object
-        properties:
-          heading:
-            type: string
-          value:
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  authorId:
+    type: string
+    minLength: 1
+  name:
+    type: string
+    minLength: 1
+  details:
+    type: array
+    items:
+      type: object
+      properties:
+        heading:
+          type: string
+        value:
+          type: string
+          minLength: 1
+        values:
+          type: array
+          items:
             type: string
             minLength: 1
-          values:
-            type: array
-            items:
-              type: string
-              minLength: 1
-            minItems: 1
-        oneOf:
-          - required:
-              - value
-            not:
-              required:
-                - values
-          - required:
+          minItems: 1
+      oneOf:
+        - required:
+            - value
+          not:
+            required:
               - values
-            not:
-              required:
-                - value
-    orcid:
-      $ref: orcid.yaml#/schema
-    groups:
-      type: array
-      items:
-        type: object
-        properties:
-          groupName:
-            type: string
+        - required:
+            - values
+          not:
+            required:
+              - value
+  orcid:
+    $ref: orcid.yaml#/schema
+  groups:
+    type: array
+    items:
+      type: object
+      properties:
+        groupName:
+          type: string
+        items:
+          type: array
           items:
-            type: array
-            items:
-              type: string
-              minLength: 1
-            minItems: 1
-        required:
-          - items
-      minItems: 1
-  required:
-    - authorId
-    - name
-  anyOf:
-    - not:
-        required:
-          - orcid
-          - groups
-    - required:
+            type: string
+            minLength: 1
+          minItems: 1
+      required:
+        - items
+    minItems: 1
+required:
+  - authorId
+  - name
+anyOf:
+  - not:
+      required:
         - orcid
-      not:
-        required:
-          - groups
-    - required:
         - groups
-      not:
-        required:
-          - orcid
+  - required:
+      - orcid
+    not:
+      required:
+        - groups
+  - required:
+      - groups
+    not:
+      required:
+        - orcid

--- a/source/_patterns/00-atoms/components/author-details.yaml
+++ b/source/_patterns/00-atoms/components/author-details.yaml
@@ -1,8 +1,3 @@
-assets:
-  css:
-    - author-details.css
-    - $ref: orcid.yaml#/assets/css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/00-atoms/components/block-link.yaml
+++ b/source/_patterns/00-atoms/components/block-link.yaml
@@ -4,7 +4,7 @@ properties:
   isGridListing:
     type: boolean
   image:
-    $ref: picture.yaml#/schema
+    $ref: picture.yaml
   text:
     type: string
     minLength: 1

--- a/source/_patterns/00-atoms/components/block-link.yaml
+++ b/source/_patterns/00-atoms/components/block-link.yaml
@@ -1,17 +1,16 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    isGridListing:
-      type: boolean
-    image:
-      $ref: picture.yaml#/schema
-    text:
-      type: string
-      minLength: 1
-    url:
-      type: string
-      minLength: 1
-  required:
-    - text
-    - url
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  isGridListing:
+    type: boolean
+  image:
+    $ref: picture.yaml#/schema
+  text:
+    type: string
+    minLength: 1
+  url:
+    type: string
+    minLength: 1
+required:
+  - text
+  - url

--- a/source/_patterns/00-atoms/components/block-link.yaml
+++ b/source/_patterns/00-atoms/components/block-link.yaml
@@ -1,7 +1,3 @@
-assets:
-  css:
-    - block-link.css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/00-atoms/components/button.yaml
+++ b/source/_patterns/00-atoms/components/button.yaml
@@ -1,34 +1,33 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  allOf:
-    - properties:
-        text:
-          type: string
-          minLength: 1
-        classes:
-          type: string
-      required:
-        - text
-    - oneOf:
-        - properties:
-            type:
-              type: string
-              enum:
-                - button
-                - reset
-                - submit
-            id:
-              type: string
-              minLength: 1
-            name:
-              type: string
-              minLength: 1
-          required:
-            - type
-        - properties:
-            path:
-              type: string
-              minLength: 1
-          required:
-            - path
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+allOf:
+  - properties:
+      text:
+        type: string
+        minLength: 1
+      classes:
+        type: string
+    required:
+      - text
+  - oneOf:
+      - properties:
+          type:
+            type: string
+            enum:
+              - button
+              - reset
+              - submit
+          id:
+            type: string
+            minLength: 1
+          name:
+            type: string
+            minLength: 1
+        required:
+          - type
+      - properties:
+          path:
+            type: string
+            minLength: 1
+        required:
+          - path

--- a/source/_patterns/00-atoms/components/button.yaml
+++ b/source/_patterns/00-atoms/components/button.yaml
@@ -1,7 +1,3 @@
-assets:
-  css:
-    - buttons.css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/00-atoms/components/caption-text.yaml
+++ b/source/_patterns/00-atoms/components/caption-text.yaml
@@ -1,7 +1,3 @@
-assets:
-  css:
-    - caption-text.css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/00-atoms/components/caption-text.yaml
+++ b/source/_patterns/00-atoms/components/caption-text.yaml
@@ -1,14 +1,13 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    heading:
-      type: string
-      minLength: 1
-    standfirst:
-      type: string
-      minLength: 1
-    text:
-      type: string
-      minLength: 1
-  minProperties: 1
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  heading:
+    type: string
+    minLength: 1
+  standfirst:
+    type: string
+    minLength: 1
+  text:
+    type: string
+    minLength: 1
+minProperties: 1

--- a/source/_patterns/00-atoms/components/code.yaml
+++ b/source/_patterns/00-atoms/components/code.yaml
@@ -1,7 +1,3 @@
-assets:
-  css:
-    - code.css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/00-atoms/components/code.yaml
+++ b/source/_patterns/00-atoms/components/code.yaml
@@ -1,9 +1,8 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-      code:
-        type: string
-        minLength: 1
-  required:
-    - code
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+    code:
+      type: string
+      minLength: 1
+required:
+  - code

--- a/source/_patterns/00-atoms/components/date.yaml
+++ b/source/_patterns/00-atoms/components/date.yaml
@@ -1,33 +1,32 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    forMachine:
-      type: string
-      pattern: ^([12][0-9]{3})-([0-9]{2})-([0-9]{2})$
-    forHuman:
-      type: object
-      properties:
-        dayOfMonth:
-          type: integer
-          minimum: 1
-          maximum: 31
-        month:
-          type: string
-          minLength: 3
-          maxLength: 3
-        year:
-          type: integer
-      required:
-        - dayOfMonth
-        - month
-        - year
-    isUpdated:
-      type: boolean
-      default: false
-    isExpanded:
-      type: boolean
-      default: false
-  required:
-    - forHuman
-    - forMachine
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  forMachine:
+    type: string
+    pattern: ^([12][0-9]{3})-([0-9]{2})-([0-9]{2})$
+  forHuman:
+    type: object
+    properties:
+      dayOfMonth:
+        type: integer
+        minimum: 1
+        maximum: 31
+      month:
+        type: string
+        minLength: 3
+        maxLength: 3
+      year:
+        type: integer
+    required:
+      - dayOfMonth
+      - month
+      - year
+  isUpdated:
+    type: boolean
+    default: false
+  isExpanded:
+    type: boolean
+    default: false
+required:
+  - forHuman
+  - forMachine

--- a/source/_patterns/00-atoms/components/date.yaml
+++ b/source/_patterns/00-atoms/components/date.yaml
@@ -1,7 +1,3 @@
-assets:
-  css:
-    - date.css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/00-atoms/components/definition-list.yaml
+++ b/source/_patterns/00-atoms/components/definition-list.yaml
@@ -1,22 +1,21 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  items:
+    type: array
+    minItems: 1
     items:
-      type: array
-      minItems: 1
-      items:
-        type: object
-        properties:
-          term:
+      type: object
+      properties:
+        term:
+          type: string
+        descriptors:
+          type: array
+          minItems: 1
+          items:
             type: string
-          descriptors:
-            type: array
-            minItems: 1
-            items:
-              type: string
-        required:
-          - term
-          - descriptors
-  required:
-    - items
+      required:
+        - term
+        - descriptors
+required:
+  - items

--- a/source/_patterns/00-atoms/components/definition-list.yaml
+++ b/source/_patterns/00-atoms/components/definition-list.yaml
@@ -1,7 +1,3 @@
-assets:
-  css:
-    - definition-list.css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/00-atoms/components/doi.yaml
+++ b/source/_patterns/00-atoms/components/doi.yaml
@@ -1,18 +1,17 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    doi:
-      type: string
-      minLength: 1
-    variant:
-      type: string
-      enum:
-        - article-section
-        - asset
-    isTruncated:
-      type: boolean
-      default:
-        - false
-  required:
-    - doi
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  doi:
+    type: string
+    minLength: 1
+  variant:
+    type: string
+    enum:
+      - article-section
+      - asset
+  isTruncated:
+    type: boolean
+    default:
+      - false
+required:
+  - doi

--- a/source/_patterns/00-atoms/components/doi.yaml
+++ b/source/_patterns/00-atoms/components/doi.yaml
@@ -1,7 +1,3 @@
-assets:
-  css:
-    - doi.css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/00-atoms/components/iframe.yaml
+++ b/source/_patterns/00-atoms/components/iframe.yaml
@@ -1,16 +1,15 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    src:
-      type: string
-      minLength: 1
-    allowFullScreen:
-      type: boolean
-      default: false
-    paddingBottom:
-      type: number # (height/width)×100
-      minimum: 1
-  required:
-    - src
-    - paddingBottom
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  src:
+    type: string
+    minLength: 1
+  allowFullScreen:
+    type: boolean
+    default: false
+  paddingBottom:
+    type: number # (height/width)×100
+    minimum: 1
+required:
+  - src
+  - paddingBottom

--- a/source/_patterns/00-atoms/components/iframe.yaml
+++ b/source/_patterns/00-atoms/components/iframe.yaml
@@ -1,7 +1,3 @@
-assets:
-  css:
-    - iframe.css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/00-atoms/components/image-link.yaml
+++ b/source/_patterns/00-atoms/components/image-link.yaml
@@ -5,7 +5,7 @@ properties:
     type: string
     minLength: 1
   image:
-    $ref: picture.yaml#/schema
+    $ref: picture.yaml
 required:
   - url
   - image

--- a/source/_patterns/00-atoms/components/image-link.yaml
+++ b/source/_patterns/00-atoms/components/image-link.yaml
@@ -1,8 +1,3 @@
-assets:
-  css:
-    - image-link.css
-    - $ref: picture.yaml#/assets/css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/00-atoms/components/image-link.yaml
+++ b/source/_patterns/00-atoms/components/image-link.yaml
@@ -1,12 +1,11 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    url:
-      type: string
-      minLength: 1
-    image:
-      $ref: picture.yaml#/schema
-  required:
-    - url
-    - image
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  url:
+    type: string
+    minLength: 1
+  image:
+    $ref: picture.yaml#/schema
+required:
+  - url
+  - image

--- a/source/_patterns/00-atoms/components/info-bar.yaml
+++ b/source/_patterns/00-atoms/components/info-bar.yaml
@@ -1,18 +1,17 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    text:
-      type: string
-      minLength: 1
-    type:
-      type: string
-      enum:
-        - attention
-        - info
-        - multiple-versions
-        - correction
-        - success
-  required:
-    - text
-    - type
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  text:
+    type: string
+    minLength: 1
+  type:
+    type: string
+    enum:
+      - attention
+      - info
+      - multiple-versions
+      - correction
+      - success
+required:
+  - text
+  - type

--- a/source/_patterns/00-atoms/components/info-bar.yaml
+++ b/source/_patterns/00-atoms/components/info-bar.yaml
@@ -1,7 +1,3 @@
-assets:
-  css:
-    - info-bars.css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/00-atoms/components/lead-para.yaml
+++ b/source/_patterns/00-atoms/components/lead-para.yaml
@@ -1,7 +1,3 @@
-assets:
-  css:
-    - lead-para.css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/00-atoms/components/lead-para.yaml
+++ b/source/_patterns/00-atoms/components/lead-para.yaml
@@ -1,12 +1,11 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    text:
-      type: string
-      minLength: 1
-    id:
-      type: string
-      minLength: 1
-  required:
-    - text
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  text:
+    type: string
+    minLength: 1
+  id:
+    type: string
+    minLength: 1
+required:
+  - text

--- a/source/_patterns/00-atoms/components/list-heading.yaml
+++ b/source/_patterns/00-atoms/components/list-heading.yaml
@@ -1,11 +1,10 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    heading:
-      type: string
-      minLength: 1
-    headingId:
-      type: string
-  required:
-    - heading
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  heading:
+    type: string
+    minLength: 1
+  headingId:
+    type: string
+required:
+  - heading

--- a/source/_patterns/00-atoms/components/list-heading.yaml
+++ b/source/_patterns/00-atoms/components/list-heading.yaml
@@ -1,7 +1,3 @@
-assets:
-  css:
-    - list-heading.css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/00-atoms/components/list.yaml
+++ b/source/_patterns/00-atoms/components/list.yaml
@@ -1,27 +1,26 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    isOrdered:
-      type: boolean
-    prefix:
-      type: string
-      enum:
-        - alpha-lower
-        - alpha-upper
-        - bullet
-        - number
-        - roman-lower
-        - roman-upper
-    classes:
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  isOrdered:
+    type: boolean
+  prefix:
+    type: string
+    enum:
+      - alpha-lower
+      - alpha-upper
+      - bullet
+      - number
+      - roman-lower
+      - roman-upper
+  classes:
+    type: string
+    minLength: 1
+  items:
+    type: array
+    items:
       type: string
       minLength: 1
-    items:
-      type: array
-      items:
-        type: string
-        minLength: 1
-      minItems: 1
-  required:
-    - isOrdered
-    - items
+    minItems: 1
+required:
+  - isOrdered
+  - items

--- a/source/_patterns/00-atoms/components/list.yaml
+++ b/source/_patterns/00-atoms/components/list.yaml
@@ -1,7 +1,3 @@
-assets:
-  css:
-    - list.css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/00-atoms/components/math.yaml
+++ b/source/_patterns/00-atoms/components/math.yaml
@@ -1,15 +1,14 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    id:
-      type: string
-      minLength: 1
-    label:
-      type: string
-      minLength: 1
-    math:
-      type: string
-      pattern: ^<math>.*<\/math>$
-  required:
-    - math
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  id:
+    type: string
+    minLength: 1
+  label:
+    type: string
+    minLength: 1
+  math:
+    type: string
+    pattern: ^<math>.*<\/math>$
+required:
+  - math

--- a/source/_patterns/00-atoms/components/math.yaml
+++ b/source/_patterns/00-atoms/components/math.yaml
@@ -1,7 +1,3 @@
-assets:
-  css:
-    - math.css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/00-atoms/components/media-source.yaml
+++ b/source/_patterns/00-atoms/components/media-source.yaml
@@ -1,7 +1,3 @@
-assets:
-  css:
-    - media-source.css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   properties:

--- a/source/_patterns/00-atoms/components/media-source.yaml
+++ b/source/_patterns/00-atoms/components/media-source.yaml
@@ -1,35 +1,34 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  properties:
-    src:
-      type: string
-      minLength: 1
-    fallback:
-      type: object
-      properties:
-        classes:
-          type: string
-          min-length: 1
-        isExternal:
-          type: boolean
-          default: false
-        # Content might not be just text, could be an html chunk: if so it must be pre-prepared as a string, it it will
-        # be included within an <a> element so must not include a link (is that regex possible?).
-        content:
-          type: string
-          minLength: 1
-    mediaType:
-      type: object
-      properties:
-        forMachine:
-          type: string
-          # Note that any codec subattribute of forMachine must be specified with double quotes, not single quotes. The
-          # mustache file has the type attribute set within single quotes to accommodate this, so the final HTML result
-          # should end up looking like this (but with differing values as appropriate):
-          #   type='video/webm; codecs="vp8.0, vorbis"'
-          pattern: ^(audio)|(video)\/.+$
-        forHuman:
-          type: string
-          minLength: 1
-  required:
-    - src
+$schema: http://json-schema.org/draft-04/schema#
+properties:
+  src:
+    type: string
+    minLength: 1
+  fallback:
+    type: object
+    properties:
+      classes:
+        type: string
+        min-length: 1
+      isExternal:
+        type: boolean
+        default: false
+      # Content might not be just text, could be an html chunk: if so it must be pre-prepared as a string, it it will
+      # be included within an <a> element so must not include a link (is that regex possible?).
+      content:
+        type: string
+        minLength: 1
+  mediaType:
+    type: object
+    properties:
+      forMachine:
+        type: string
+        # Note that any codec subattribute of forMachine must be specified with double quotes, not single quotes. The
+        # mustache file has the type attribute set within single quotes to accommodate this, so the final HTML result
+        # should end up looking like this (but with differing values as appropriate):
+        #   type='video/webm; codecs="vp8.0, vorbis"'
+        pattern: ^(audio)|(video)\/.+$
+      forHuman:
+        type: string
+        minLength: 1
+required:
+  - src

--- a/source/_patterns/00-atoms/components/message-bar.yaml
+++ b/source/_patterns/00-atoms/components/message-bar.yaml
@@ -1,7 +1,3 @@
-assets:
-  css:
-    - message-bar.css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/00-atoms/components/message-bar.yaml
+++ b/source/_patterns/00-atoms/components/message-bar.yaml
@@ -1,9 +1,8 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    message:
-      type: string
-      minLength: 1
-  required:
-    - message
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  message:
+    type: string
+    minLength: 1
+required:
+  - message

--- a/source/_patterns/00-atoms/components/nav-linked-item.yaml
+++ b/source/_patterns/00-atoms/components/nav-linked-item.yaml
@@ -1,7 +1,3 @@
-assets:
-  css:
-    - $ref: ../../00-atoms/components/button.yaml#/assets/css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/00-atoms/components/nav-linked-item.yaml
+++ b/source/_patterns/00-atoms/components/nav-linked-item.yaml
@@ -1,40 +1,39 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  allOf:
-    -
-      properties:
-        classes:
-          type: string
-    -
-      oneOf:
-        -
-          properties:
-            text:
-              type: string
-              minLength: 1
-            textClasses:
-              type: string
-            path:
-              type: string
-              minLength: 1
-            rel:
-              type: string
-              enum:
-                - search
-            picture:
-              $ref: picture.yaml#/schema
-          required:
-            - text
-        -
-          properties:
-            button:
-              $ref: button.yaml#/schema
-          required:
-            - button
-        -
-          properties:
-            loginControl:
-              $ref: ../../01-molecules/navigation/login-control.yaml#/schema
-          required:
-            - loginControl
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+allOf:
+  -
+    properties:
+      classes:
+        type: string
+  -
+    oneOf:
+      -
+        properties:
+          text:
+            type: string
+            minLength: 1
+          textClasses:
+            type: string
+          path:
+            type: string
+            minLength: 1
+          rel:
+            type: string
+            enum:
+              - search
+          picture:
+            $ref: picture.yaml#/schema
+        required:
+          - text
+      -
+        properties:
+          button:
+            $ref: button.yaml#/schema
+        required:
+          - button
+      -
+        properties:
+          loginControl:
+            $ref: ../../01-molecules/navigation/login-control.yaml#/schema
+        required:
+          - loginControl

--- a/source/_patterns/00-atoms/components/nav-linked-item.yaml
+++ b/source/_patterns/00-atoms/components/nav-linked-item.yaml
@@ -22,18 +22,18 @@ allOf:
             enum:
               - search
           picture:
-            $ref: picture.yaml#/schema
+            $ref: picture.yaml
         required:
           - text
       -
         properties:
           button:
-            $ref: button.yaml#/schema
+            $ref: button.yaml
         required:
           - button
       -
         properties:
           loginControl:
-            $ref: ../../01-molecules/navigation/login-control.yaml#/schema
+            $ref: ../../01-molecules/navigation/login-control.yaml
         required:
           - loginControl

--- a/source/_patterns/00-atoms/components/orcid.yaml
+++ b/source/_patterns/00-atoms/components/orcid.yaml
@@ -1,9 +1,8 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    id:
-      type: string
-      pattern: ^([0-9]{4}-){3}[0-9]{3}[0-9X]$
-  required:
-    - id
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  id:
+    type: string
+    pattern: ^([0-9]{4}-){3}[0-9]{3}[0-9X]$
+required:
+  - id

--- a/source/_patterns/00-atoms/components/orcid.yaml
+++ b/source/_patterns/00-atoms/components/orcid.yaml
@@ -1,7 +1,3 @@
-assets:
-  css:
-    - orcid.css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/00-atoms/components/paragraph.yaml
+++ b/source/_patterns/00-atoms/components/paragraph.yaml
@@ -1,6 +1,3 @@
-assets:
-  css: []
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/00-atoms/components/paragraph.yaml
+++ b/source/_patterns/00-atoms/components/paragraph.yaml
@@ -1,9 +1,8 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    text:
-      type: string
-      minLength: 1
-  required:
-    - text
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  text:
+    type: string
+    minLength: 1
+required:
+  - text

--- a/source/_patterns/00-atoms/components/picture.yaml
+++ b/source/_patterns/00-atoms/components/picture.yaml
@@ -1,46 +1,45 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    pictureClasses:
-      type: string
-      minLength: 1
-    sources:
-      type: array
-      uniqueItems: true
-      items:
-        type: object
-        properties:
-          srcset:
-            type: string
-            minLength: 1
-          media:
-            type: string
-            minLength: 1
-          type:
-            type: string
-            enum:
-              - image/svg+xml
-              - image/webp
-              - image/png
-              - image/jpeg
-        required:
-          - srcset
-    fallback:
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  pictureClasses:
+    type: string
+    minLength: 1
+  sources:
+    type: array
+    uniqueItems: true
+    items:
       type: object
       properties:
         srcset:
           type: string
-          pattern: ^((https)?[^ ]+ [1-9][0-9.]*x, )*((https?)?[^ ]+ 1x)$
-        defaultPath:
+          minLength: 1
+        media:
           type: string
           minLength: 1
-        altText:
+        type:
           type: string
-        classes:
-          type: string
+          enum:
+            - image/svg+xml
+            - image/webp
+            - image/png
+            - image/jpeg
       required:
-        - defaultPath
-        - altText
-  required:
-    - fallback
+        - srcset
+  fallback:
+    type: object
+    properties:
+      srcset:
+        type: string
+        pattern: ^((https)?[^ ]+ [1-9][0-9.]*x, )*((https?)?[^ ]+ 1x)$
+      defaultPath:
+        type: string
+        minLength: 1
+      altText:
+        type: string
+      classes:
+        type: string
+    required:
+      - defaultPath
+      - altText
+required:
+  - fallback

--- a/source/_patterns/00-atoms/components/picture.yaml
+++ b/source/_patterns/00-atoms/components/picture.yaml
@@ -1,6 +1,3 @@
-assets:
-  css: []
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/00-atoms/components/section-listing-link.yaml
+++ b/source/_patterns/00-atoms/components/section-listing-link.yaml
@@ -1,7 +1,3 @@
-assets:
-  css:
-    - section-listing-link.css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/00-atoms/components/section-listing-link.yaml
+++ b/source/_patterns/00-atoms/components/section-listing-link.yaml
@@ -1,13 +1,12 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    targetFragmentId:
-      type: string
-      minLength: 1
-    text:
-      type: string
-      minLength: 1
-  required:
-    - targetFragmentId
-    - text
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  targetFragmentId:
+    type: string
+    minLength: 1
+  text:
+    type: string
+    minLength: 1
+required:
+  - targetFragmentId
+  - text

--- a/source/_patterns/00-atoms/components/see-more-link.yaml
+++ b/source/_patterns/00-atoms/components/see-more-link.yaml
@@ -1,7 +1,3 @@
-assets:
-  css:
-    - see-more-link.css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/00-atoms/components/see-more-link.yaml
+++ b/source/_patterns/00-atoms/components/see-more-link.yaml
@@ -1,15 +1,14 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    url:
-      type: string
-      minLength: 1
-    name:
-      type: string
-      minLength: 1
-    isInline:
-      type: boolean
-  required:
-    - url
-    - name
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  url:
+    type: string
+    minLength: 1
+  name:
+    type: string
+    minLength: 1
+  isInline:
+    type: boolean
+required:
+  - url
+  - name

--- a/source/_patterns/00-atoms/components/social-media-sharers.yaml
+++ b/source/_patterns/00-atoms/components/social-media-sharers.yaml
@@ -1,7 +1,3 @@
-assets:
-  css:
-    - social-media-sharers.css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/00-atoms/components/social-media-sharers.yaml
+++ b/source/_patterns/00-atoms/components/social-media-sharers.yaml
@@ -1,21 +1,20 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    facebookUrl:
-      type: string
-      format: uri
-    twitterUrl:
-      type: string
-      format: uri
-    emailUrl:
-      type: string
-      format: uri
-    redditUrl:
-      type: string
-      format: uri
-  required:
-    - facebookUrl
-    - twitterUrl
-    - emailUrl
-    - redditUrl
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  facebookUrl:
+    type: string
+    format: uri
+  twitterUrl:
+    type: string
+    format: uri
+  emailUrl:
+    type: string
+    format: uri
+  redditUrl:
+    type: string
+    format: uri
+required:
+  - facebookUrl
+  - twitterUrl
+  - emailUrl
+  - redditUrl

--- a/source/_patterns/00-atoms/components/speech-bubble.yaml
+++ b/source/_patterns/00-atoms/components/speech-bubble.yaml
@@ -1,7 +1,3 @@
-assets:
-  css:
-    - speech-bubble.css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/00-atoms/components/speech-bubble.yaml
+++ b/source/_patterns/00-atoms/components/speech-bubble.yaml
@@ -1,34 +1,33 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    text:
-      type: string
-    isSmall:
-      type: boolean
-      enum:
-        - true
-    hasPlaceholder:
-      type: boolean
-      enum:
-        - true
-    behaviour:
-      type: string
-      minLength: 1
-  required:
-    - text
-  anyOf:
-    - required:
-      - isSmall
-      not:
-        required:
-          - hasPlaceholder
-    - required:
-      - hasPlaceholder
-      not:
-        required:
-          - isSmall
-    - not:
-        required:
-          - isSmall
-          - hasPlaceholder
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  text:
+    type: string
+  isSmall:
+    type: boolean
+    enum:
+      - true
+  hasPlaceholder:
+    type: boolean
+    enum:
+      - true
+  behaviour:
+    type: string
+    minLength: 1
+required:
+  - text
+anyOf:
+  - required:
+    - isSmall
+    not:
+      required:
+        - hasPlaceholder
+  - required:
+    - hasPlaceholder
+    not:
+      required:
+        - isSmall
+  - not:
+      required:
+        - isSmall
+        - hasPlaceholder

--- a/source/_patterns/00-atoms/components/table.yaml
+++ b/source/_patterns/00-atoms/components/table.yaml
@@ -1,7 +1,3 @@
-assets:
-  css:
-    - table.css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/00-atoms/components/table.yaml
+++ b/source/_patterns/00-atoms/components/table.yaml
@@ -1,39 +1,38 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    tables:
-      type: array
-      minItems: 1
-      items:
-        type: string
-        pattern: ^<table>.*<\/table>$
-    hasFootnotes:
-      type: boolean
-      enum:
-        - true
-    footnotes:
-      type: array
-      minItems: 1
-      items:
-        type: object
-        properties:
-          text:
-            type: string
-            minLength: 1
-          footnoteId:
-            type: string
-            minLength: 1
-          footnoteLabel:
-            type: string
-            minLength: 1
-        required:
-          - text
-        dependencies:
-          footnoteId: [footnoteLabel]
-          footnoteLabel: [footnoteId]
-  required:
-    - tables
-  dependencies:
-    hasFootnotes: [footnotes]
-    footnotes: [hasFootnotes]
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  tables:
+    type: array
+    minItems: 1
+    items:
+      type: string
+      pattern: ^<table>.*<\/table>$
+  hasFootnotes:
+    type: boolean
+    enum:
+      - true
+  footnotes:
+    type: array
+    minItems: 1
+    items:
+      type: object
+      properties:
+        text:
+          type: string
+          minLength: 1
+        footnoteId:
+          type: string
+          minLength: 1
+        footnoteLabel:
+          type: string
+          minLength: 1
+      required:
+        - text
+      dependencies:
+        footnoteId: [footnoteLabel]
+        footnoteLabel: [footnoteId]
+required:
+  - tables
+dependencies:
+  hasFootnotes: [footnotes]
+  footnotes: [hasFootnotes]

--- a/source/_patterns/00-atoms/components/video.yaml
+++ b/source/_patterns/00-atoms/components/video.yaml
@@ -1,20 +1,19 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    posterFrame:
-      type: string
-      minLength: 1
-    sources:
-      type: array
-      minItems: 1
-      items:
-        $ref: media-source.yaml#/schema
-    autoplay:
-      type: boolean
-      default: false
-    loop:
-      type: boolean
-      default: false
-  required:
-    - sources
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  posterFrame:
+    type: string
+    minLength: 1
+  sources:
+    type: array
+    minItems: 1
+    items:
+      $ref: media-source.yaml#/schema
+  autoplay:
+    type: boolean
+    default: false
+  loop:
+    type: boolean
+    default: false
+required:
+  - sources

--- a/source/_patterns/00-atoms/components/video.yaml
+++ b/source/_patterns/00-atoms/components/video.yaml
@@ -1,7 +1,3 @@
-assets:
-  css:
-    - $ref: media-source.yaml#/assets/css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/00-atoms/components/video.yaml
+++ b/source/_patterns/00-atoms/components/video.yaml
@@ -8,7 +8,7 @@ properties:
     type: array
     minItems: 1
     items:
-      $ref: media-source.yaml#/schema
+      $ref: media-source.yaml
   autoplay:
     type: boolean
     default: false

--- a/source/_patterns/00-atoms/errors/client-error.yaml
+++ b/source/_patterns/00-atoms/errors/client-error.yaml
@@ -1,8 +1,3 @@
-assets:
-  css:
-    - errors.css
-    - $ref: ../components/button.yaml#/assets/css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/00-atoms/errors/client-error.yaml
+++ b/source/_patterns/00-atoms/errors/client-error.yaml
@@ -1,6 +1,5 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    button:
-      $ref: ../components/button.yaml#/schema
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  button:
+    $ref: ../components/button.yaml#/schema

--- a/source/_patterns/00-atoms/errors/client-error.yaml
+++ b/source/_patterns/00-atoms/errors/client-error.yaml
@@ -2,4 +2,4 @@ $schema: http://json-schema.org/draft-04/schema#
 type: object
 properties:
   button:
-    $ref: ../components/button.yaml#/schema
+    $ref: ../components/button.yaml

--- a/source/_patterns/00-atoms/errors/not-found.yaml
+++ b/source/_patterns/00-atoms/errors/not-found.yaml
@@ -1,8 +1,3 @@
-assets:
-  css:
-    - errors.css
-    - $ref: ../components/button.yaml#/assets/css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/00-atoms/errors/not-found.yaml
+++ b/source/_patterns/00-atoms/errors/not-found.yaml
@@ -1,6 +1,5 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    button:
-      $ref: ../components/button.yaml#/schema
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  button:
+    $ref: ../components/button.yaml#/schema

--- a/source/_patterns/00-atoms/errors/not-found.yaml
+++ b/source/_patterns/00-atoms/errors/not-found.yaml
@@ -2,4 +2,4 @@ $schema: http://json-schema.org/draft-04/schema#
 type: object
 properties:
   button:
-    $ref: ../components/button.yaml#/schema
+    $ref: ../components/button.yaml

--- a/source/_patterns/00-atoms/errors/server-error.yaml
+++ b/source/_patterns/00-atoms/errors/server-error.yaml
@@ -1,8 +1,3 @@
-assets:
-  css:
-    - errors.css
-    - $ref: ../components/button.yaml#/assets/css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/00-atoms/errors/server-error.yaml
+++ b/source/_patterns/00-atoms/errors/server-error.yaml
@@ -1,6 +1,5 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    button:
-      $ref: ../components/button.yaml#/schema
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  button:
+    $ref: ../components/button.yaml#/schema

--- a/source/_patterns/00-atoms/errors/server-error.yaml
+++ b/source/_patterns/00-atoms/errors/server-error.yaml
@@ -2,4 +2,4 @@ $schema: http://json-schema.org/draft-04/schema#
 type: object
 properties:
   button:
-    $ref: ../components/button.yaml#/schema
+    $ref: ../components/button.yaml

--- a/source/_patterns/00-atoms/errors/service-unavailable.yaml
+++ b/source/_patterns/00-atoms/errors/service-unavailable.yaml
@@ -1,8 +1,3 @@
-assets:
-  css:
-    - errors.css
-    - $ref: ../components/button.yaml#/assets/css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/00-atoms/errors/service-unavailable.yaml
+++ b/source/_patterns/00-atoms/errors/service-unavailable.yaml
@@ -1,6 +1,5 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    button:
-      $ref: ../components/button.yaml#/schema
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  button:
+    $ref: ../components/button.yaml#/schema

--- a/source/_patterns/00-atoms/errors/service-unavailable.yaml
+++ b/source/_patterns/00-atoms/errors/service-unavailable.yaml
@@ -2,4 +2,4 @@ $schema: http://json-schema.org/draft-04/schema#
 type: object
 properties:
   button:
-    $ref: ../components/button.yaml#/schema
+    $ref: ../components/button.yaml

--- a/source/_patterns/00-atoms/forms/form-field-info-link.yaml
+++ b/source/_patterns/00-atoms/forms/form-field-info-link.yaml
@@ -1,7 +1,3 @@
-assets:
-  css:
-    - form-field-info-link.css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/00-atoms/forms/form-field-info-link.yaml
+++ b/source/_patterns/00-atoms/forms/form-field-info-link.yaml
@@ -1,17 +1,16 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    name:
-      type: string
-      minLength: 1
-    url:
-      type: string
-      minLength: 1
-    alignLeft:
-      type: boolean
-      enum:
-        - true
-  required:
-    - name
-    - url
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  name:
+    type: string
+    minLength: 1
+  url:
+    type: string
+    minLength: 1
+  alignLeft:
+    type: boolean
+    enum:
+      - true
+required:
+  - name
+  - url

--- a/source/_patterns/00-atoms/forms/hidden-field.yaml
+++ b/source/_patterns/00-atoms/forms/hidden-field.yaml
@@ -1,6 +1,3 @@
-assets:
-  css: []
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/00-atoms/forms/hidden-field.yaml
+++ b/source/_patterns/00-atoms/forms/hidden-field.yaml
@@ -1,13 +1,12 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    id:
-      type: string
-      minLength: 1
-    name:
-      type: string
-      minLength: 1
-    value:
-      type: string
-      minLength: 1
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  id:
+    type: string
+    minLength: 1
+  name:
+    type: string
+    minLength: 1
+  value:
+    type: string
+    minLength: 1

--- a/source/_patterns/00-atoms/forms/honeypot.yaml
+++ b/source/_patterns/00-atoms/forms/honeypot.yaml
@@ -1,2 +1,1 @@
-schema:
-  $ref: text-field.yaml#/schema
+$ref: text-field.yaml#/schema

--- a/source/_patterns/00-atoms/forms/honeypot.yaml
+++ b/source/_patterns/00-atoms/forms/honeypot.yaml
@@ -1,6 +1,2 @@
-assets:
-  css:
-    - $ref: text-field.yaml#/assets/css
-  js: []
 schema:
   $ref: text-field.yaml#/schema

--- a/source/_patterns/00-atoms/forms/honeypot.yaml
+++ b/source/_patterns/00-atoms/forms/honeypot.yaml
@@ -1,1 +1,1 @@
-$ref: text-field.yaml#/schema
+$ref: text-field.yaml

--- a/source/_patterns/00-atoms/forms/select.yaml
+++ b/source/_patterns/00-atoms/forms/select.yaml
@@ -1,65 +1,64 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    id:
-      type: string
-      minLength: 1
-    name:
-      type: string
-      minLength: 1
-    state:
-      type: string
-      enum:
-        - valid
-        - invalid
-    messageGroup:
-      type: object
-      properties:
-        errorText:
-          type: string
-          minLength: 1
-        infoText:
-          type: string
-          minLength: 1
-        id:
-          type: string
-          minLength: 1
-      minProperties: 2
-      required:
-        - id
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  id:
+    type: string
+    minLength: 1
+  name:
+    type: string
+    minLength: 1
+  state:
+    type: string
+    enum:
+      - valid
+      - invalid
+  messageGroup:
+    type: object
+    properties:
+      errorText:
+        type: string
+        minLength: 1
+      infoText:
+        type: string
+        minLength: 1
+      id:
+        type: string
+        minLength: 1
+    minProperties: 2
     required:
-      type: boolean
-    disabled:
-      type: boolean
-    label:
+      - id
+  required:
+    type: boolean
+  disabled:
+    type: boolean
+  label:
+    type: object
+    properties:
+      labelText:
+        type: string
+        minLength: 1
+      isVisuallyHidden:
+        type: boolean
+    required:
+      - labelText
+  options:
+    array: string
+    minItems: 1
+    items:
       type: object
       properties:
-        labelText:
+        value:
           type: string
           minLength: 1
-        isVisuallyHidden:
+        displayValue:
+          type: string
+          minLength: 1
+        selected:
           type: boolean
       required:
-        - labelText
-    options:
-      array: string
-      minItems: 1
-      items:
-        type: object
-        properties:
-          value:
-            type: string
-            minLength: 1
-          displayValue:
-            type: string
-            minLength: 1
-          selected:
-            type: boolean
-        required:
-          - value
-          - displayValue
-  required:
-    - options
-  dependencies:
-    label: [id]
+        - value
+        - displayValue
+required:
+  - options
+dependencies:
+  label: [id]

--- a/source/_patterns/00-atoms/forms/select.yaml
+++ b/source/_patterns/00-atoms/forms/select.yaml
@@ -1,8 +1,3 @@
-assets:
-  css:
-    - select.css
-    - form-item.css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/00-atoms/forms/text-area.yaml
+++ b/source/_patterns/00-atoms/forms/text-area.yaml
@@ -1,62 +1,61 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    id:
-      type: string
-      minLength: 1
-    name:
-      type: string
-      minLength: 1
-    state:
-      type: string
-      enum:
-        - valid
-        - invalid
-    messageGroup:
-      type: object
-      properties:
-        errorText:
-          type: string
-          minLength: 1
-        infoText:
-          type: string
-          minLength: 1
-        id:
-          type: string
-          minLength: 1
-      minProperties: 2
-      required:
-        - id
-    autofocus:
-      type: boolean
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  id:
+    type: string
+    minLength: 1
+  name:
+    type: string
+    minLength: 1
+  state:
+    type: string
+    enum:
+      - valid
+      - invalid
+  messageGroup:
+    type: object
+    properties:
+      errorText:
+        type: string
+        minLength: 1
+      infoText:
+        type: string
+        minLength: 1
+      id:
+        type: string
+        minLength: 1
+    minProperties: 2
     required:
-      type: boolean
-    cols:
-      type: integer
-    rows:
-      type: integer
-    value:
-      type: string
-      minLength: 1
-    form:
-      type: string
-      minLength: 1
-    placeholder:
-      type: string
-      minLength: 1
-    label:
-      type: object
-      properties:
-        labelText:
-          type: string
-          minLength: 1
-        isVisuallyHidden:
-          default: false
-          type: boolean
-      required:
-        - labelText
+      - id
+  autofocus:
+    type: boolean
   required:
-    - name
-  dependencies:
-    label: [id]
+    type: boolean
+  cols:
+    type: integer
+  rows:
+    type: integer
+  value:
+    type: string
+    minLength: 1
+  form:
+    type: string
+    minLength: 1
+  placeholder:
+    type: string
+    minLength: 1
+  label:
+    type: object
+    properties:
+      labelText:
+        type: string
+        minLength: 1
+      isVisuallyHidden:
+        default: false
+        type: boolean
+    required:
+      - labelText
+required:
+  - name
+dependencies:
+  label: [id]

--- a/source/_patterns/00-atoms/forms/text-area.yaml
+++ b/source/_patterns/00-atoms/forms/text-area.yaml
@@ -1,8 +1,3 @@
-assets:
-  css:
-    - text-fields.css
-    - form-item.css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/00-atoms/forms/text-field.yaml
+++ b/source/_patterns/00-atoms/forms/text-field.yaml
@@ -1,65 +1,64 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    id:
-      type: string
-      minLength: 1
-    name:
-      type: string
-      minLength: 1
-    state:
-      type: string
-      enum:
-        - valid
-        - invalid
-    messageGroup:
-      type: object
-      properties:
-        errorText:
-          type: string
-          minLength: 1
-        infoText:
-          type: string
-          minLength: 1
-        id:
-          type: string
-          minLength: 1
-      minProperties: 2
-      required:
-        - id
-    autofocus:
-      type: boolean
-    inputType:
-      type: string
-      enum:
-        - email
-        - password
-        - search
-        - tel
-        - text
-        - url
-      minLength: 1
-    placeholder:
-      type: string
-      minLength: 1
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  id:
+    type: string
+    minLength: 1
+  name:
+    type: string
+    minLength: 1
+  state:
+    type: string
+    enum:
+      - valid
+      - invalid
+  messageGroup:
+    type: object
+    properties:
+      errorText:
+        type: string
+        minLength: 1
+      infoText:
+        type: string
+        minLength: 1
+      id:
+        type: string
+        minLength: 1
+    minProperties: 2
     required:
-      type: boolean
-    disabled:
-      type: boolean
-    label:
-      type: object
-      properties:
-        labelText:
-          type: string
-          minLength: 1
-        isVisuallyHidden:
-          type: boolean
-      required:
-        - labelText
-    formFieldInfoLink:
-      $ref: form-field-info-link.yaml#/schema
+      - id
+  autofocus:
+    type: boolean
+  inputType:
+    type: string
+    enum:
+      - email
+      - password
+      - search
+      - tel
+      - text
+      - url
+    minLength: 1
+  placeholder:
+    type: string
+    minLength: 1
   required:
-    - inputType
-  dependencies:
-    label: [id]
+    type: boolean
+  disabled:
+    type: boolean
+  label:
+    type: object
+    properties:
+      labelText:
+        type: string
+        minLength: 1
+      isVisuallyHidden:
+        type: boolean
+    required:
+      - labelText
+  formFieldInfoLink:
+    $ref: form-field-info-link.yaml#/schema
+required:
+  - inputType
+dependencies:
+  label: [id]

--- a/source/_patterns/00-atoms/forms/text-field.yaml
+++ b/source/_patterns/00-atoms/forms/text-field.yaml
@@ -57,7 +57,7 @@ properties:
     required:
       - labelText
   formFieldInfoLink:
-    $ref: form-field-info-link.yaml#/schema
+    $ref: form-field-info-link.yaml
 required:
   - inputType
 dependencies:

--- a/source/_patterns/00-atoms/forms/text-field.yaml
+++ b/source/_patterns/00-atoms/forms/text-field.yaml
@@ -1,9 +1,3 @@
-assets:
-  css:
-    - text-fields.css
-    - form-item.css
-    - $ref: form-field-info-link.yaml#/assets/css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/00-atoms/references/reference.yaml
+++ b/source/_patterns/00-atoms/references/reference.yaml
@@ -5,7 +5,7 @@ properties:
     type: string
     minLength: 1
   doi:
-    $ref: ../components/doi.yaml#/schema
+    $ref: ../components/doi.yaml
   title:
     type: string
     minLength: 1

--- a/source/_patterns/00-atoms/references/reference.yaml
+++ b/source/_patterns/00-atoms/references/reference.yaml
@@ -1,8 +1,3 @@
-assets:
-  css:
-    - reference.css
-    - $ref: ../components/doi.yaml#/assets/css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/00-atoms/references/reference.yaml
+++ b/source/_patterns/00-atoms/references/reference.yaml
@@ -1,77 +1,76 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    titleLink:
-      type: string
-      minLength: 1
-    doi:
-      $ref: ../components/doi.yaml#/schema
-    title:
-      type: string
-      minLength: 1
-    hasAuthors:
-      type: boolean
-    authorLists:
-      type: array
-      minItems: 1
-      items:
-        type: object
-        properties:
-          authors:
-            type: array
-            minItems: 1
-            items:
-              type: object
-              properties:
-                name:
-                  type: string
-                  minLength: 1
-                url:
-                  oneOf:
-                    - type: string
-                      minLength: 1
-                    - type: boolean
-                      enum:
-                        - false
-              required:
-                - name
-                - url
-          suffix:
-            type: string
-            minLength: 1
-        required:
-          - authors
-          - suffix
-    origin:
-      type: string
-      minLength: 1
-    hasAbstracts:
-      type: boolean
-    abstracts:
-      type: array
-      minItems: 1
-      items:
-        type: object
-        properties:
-          name:
-            type: string
-            minLength: 1
-          url:
-            type: string
-            minLength: 1
-        required:
-          - name
-          - url
-  allOf:
-    -
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  titleLink:
+    type: string
+    minLength: 1
+  doi:
+    $ref: ../components/doi.yaml#/schema
+  title:
+    type: string
+    minLength: 1
+  hasAuthors:
+    type: boolean
+  authorLists:
+    type: array
+    minItems: 1
+    items:
+      type: object
+      properties:
+        authors:
+          type: array
+          minItems: 1
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+                minLength: 1
+              url:
+                oneOf:
+                  - type: string
+                    minLength: 1
+                  - type: boolean
+                    enum:
+                      - false
+            required:
+              - name
+              - url
+        suffix:
+          type: string
+          minLength: 1
       required:
-        - title
-        - hasAuthors
-        - hasAbstracts
-    #  titleLink and DOI should be mutually exclusive
-    -
-      not:
-        required:
-          - doi
-          - titleLink
+        - authors
+        - suffix
+  origin:
+    type: string
+    minLength: 1
+  hasAbstracts:
+    type: boolean
+  abstracts:
+    type: array
+    minItems: 1
+    items:
+      type: object
+      properties:
+        name:
+          type: string
+          minLength: 1
+        url:
+          type: string
+          minLength: 1
+      required:
+        - name
+        - url
+allOf:
+  -
+    required:
+      - title
+      - hasAuthors
+      - hasAbstracts
+  #  titleLink and DOI should be mutually exclusive
+  -
+    not:
+      required:
+        - doi
+        - titleLink

--- a/source/_patterns/01-molecules/components/about-profile.yaml
+++ b/source/_patterns/01-molecules/components/about-profile.yaml
@@ -1,7 +1,3 @@
-assets:
-  css:
-    - about-profile.css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/01-molecules/components/about-profile.yaml
+++ b/source/_patterns/01-molecules/components/about-profile.yaml
@@ -1,17 +1,16 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    name:
-      type: string
-      minLength: 1
-    role:
-      type: string
-      minLength: 1
-    image:
-      $ref: ../../00-atoms/components/picture.yaml#/schema
-    profile:
-      type: string
-      minLength: 1
-  required:
-    - name
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  name:
+    type: string
+    minLength: 1
+  role:
+    type: string
+    minLength: 1
+  image:
+    $ref: ../../00-atoms/components/picture.yaml#/schema
+  profile:
+    type: string
+    minLength: 1
+required:
+  - name

--- a/source/_patterns/01-molecules/components/about-profile.yaml
+++ b/source/_patterns/01-molecules/components/about-profile.yaml
@@ -8,7 +8,7 @@ properties:
     type: string
     minLength: 1
   image:
-    $ref: ../../00-atoms/components/picture.yaml#/schema
+    $ref: ../../00-atoms/components/picture.yaml
   profile:
     type: string
     minLength: 1

--- a/source/_patterns/01-molecules/components/additional-asset.yaml
+++ b/source/_patterns/01-molecules/components/additional-asset.yaml
@@ -1,42 +1,41 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    assetId:
-      type: string
-      minLength: 1
-    captionText:
-      $ref: ../../00-atoms/components/caption-text.yaml#/schema
-    doi:
-      $ref: ../../00-atoms/components/doi.yaml#/schema
-    nonDoiLink:
-      type: string
-      minLength: 1
-    downloadLink:
-      type: object
-      properties:
-        url:
-          type: string
-          minLength: 1
-        name:
-          type: string
-          minLength: 1
-        fileName:
-          type: string
-          minLength: 1
-      required:
-        - url
-        - name
-  allOf:
-    -
-      required:
-        - assetId
-        - captionText
-    -
-      oneOf:
-        -
-          required:
-            - doi
-        -
-          required:
-            - nonDoiLink
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  assetId:
+    type: string
+    minLength: 1
+  captionText:
+    $ref: ../../00-atoms/components/caption-text.yaml#/schema
+  doi:
+    $ref: ../../00-atoms/components/doi.yaml#/schema
+  nonDoiLink:
+    type: string
+    minLength: 1
+  downloadLink:
+    type: object
+    properties:
+      url:
+        type: string
+        minLength: 1
+      name:
+        type: string
+        minLength: 1
+      fileName:
+        type: string
+        minLength: 1
+    required:
+      - url
+      - name
+allOf:
+  -
+    required:
+      - assetId
+      - captionText
+  -
+    oneOf:
+      -
+        required:
+          - doi
+      -
+        required:
+          - nonDoiLink

--- a/source/_patterns/01-molecules/components/additional-asset.yaml
+++ b/source/_patterns/01-molecules/components/additional-asset.yaml
@@ -1,9 +1,3 @@
-assets:
-  css:
-    - additional-asset.css
-    - $ref: ../../00-atoms/components/caption-text.yaml#/assets/css
-    - $ref: ../../00-atoms/components/doi.yaml#/assets/css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/01-molecules/components/additional-asset.yaml
+++ b/source/_patterns/01-molecules/components/additional-asset.yaml
@@ -5,9 +5,9 @@ properties:
     type: string
     minLength: 1
   captionText:
-    $ref: ../../00-atoms/components/caption-text.yaml#/schema
+    $ref: ../../00-atoms/components/caption-text.yaml
   doi:
-    $ref: ../../00-atoms/components/doi.yaml#/schema
+    $ref: ../../00-atoms/components/doi.yaml
   nonDoiLink:
     type: string
     minLength: 1

--- a/source/_patterns/01-molecules/components/archive-nav-link.yaml
+++ b/source/_patterns/01-molecules/components/archive-nav-link.yaml
@@ -2,7 +2,7 @@ $schema: http://json-schema.org/draft-04/schema#
 type: object
 properties:
   blockLink:
-    $ref: ../../00-atoms/components/block-link.yaml#/schema
+    $ref: ../../00-atoms/components/block-link.yaml
   label:
     type: string
     minLength: 1

--- a/source/_patterns/01-molecules/components/archive-nav-link.yaml
+++ b/source/_patterns/01-molecules/components/archive-nav-link.yaml
@@ -1,29 +1,28 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    blockLink:
-      $ref: ../../00-atoms/components/block-link.yaml#/schema
-    label:
-      type: string
-      minLength: 1
-    links:
-      type: array
-      minItems: 1
-      items:
-        type: object
-        properties:
-          name:
-            type: string
-            minLength: 1
-          url:
-            type: string
-            minLength: 1
-        required:
-          - name
-          - url
-  required:
-    - blockLink
-  dependencies:
-    label: [links]
-    links: [label]
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  blockLink:
+    $ref: ../../00-atoms/components/block-link.yaml#/schema
+  label:
+    type: string
+    minLength: 1
+  links:
+    type: array
+    minItems: 1
+    items:
+      type: object
+      properties:
+        name:
+          type: string
+          minLength: 1
+        url:
+          type: string
+          minLength: 1
+      required:
+        - name
+        - url
+required:
+  - blockLink
+dependencies:
+  label: [links]
+  links: [label]

--- a/source/_patterns/01-molecules/components/archive-nav-link.yaml
+++ b/source/_patterns/01-molecules/components/archive-nav-link.yaml
@@ -1,8 +1,3 @@
-assets:
-  css:
-    - archive-nav-link.css
-    - $ref: ../../00-atoms/components/block-link.yaml#/assets/css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/01-molecules/components/article-download-links-list.yaml
+++ b/source/_patterns/01-molecules/components/article-download-links-list.yaml
@@ -1,53 +1,52 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    id:
-      type: string
-      minLength: 1
-    description:
-      type: string
-      minLength: 1
-    groups:
-      type: array
-      minItems: 1
-      items:
-        type: object
-        properties:
-          title:
-            type: string
-            minLength: 1
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  id:
+    type: string
+    minLength: 1
+  description:
+    type: string
+    minLength: 1
+  groups:
+    type: array
+    minItems: 1
+    items:
+      type: object
+      properties:
+        title:
+          type: string
+          minLength: 1
+        items:
+          type: array
+          minItems: 1
           items:
-            type: array
-            minItems: 1
-            items:
-              type: object
-              properties:
-                name:
-                  type: string
-                  minLength: 1
-                url:
-                  type: string
-                  minLength: 1
-                attributes:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      key:
-                        type: string
-                        minLength: 1
-                      value:
-                        type: string
-                    required:
-                      - key
-              required:
-                - name
-                - url
-        required:
-          - title
-          - items
-  required:
-    - id
-    - description
-    - groups
+            type: object
+            properties:
+              name:
+                type: string
+                minLength: 1
+              url:
+                type: string
+                minLength: 1
+              attributes:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    key:
+                      type: string
+                      minLength: 1
+                    value:
+                      type: string
+                  required:
+                    - key
+            required:
+              - name
+              - url
+      required:
+        - title
+        - items
+required:
+  - id
+  - description
+  - groups

--- a/source/_patterns/01-molecules/components/article-download-links-list.yaml
+++ b/source/_patterns/01-molecules/components/article-download-links-list.yaml
@@ -1,7 +1,3 @@
-assets:
-  css:
-    - article-download-links-list.css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/01-molecules/components/article-meta.yaml
+++ b/source/_patterns/01-molecules/components/article-meta.yaml
@@ -1,34 +1,33 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    groups:
-      type: array
-      minItems: 1
-      items:
-        type: object
-        properties:
-          title:
-            type: string
-            minLength: 1
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  groups:
+    type: array
+    minItems: 1
+    items:
+      type: object
+      properties:
+        title:
+          type: string
+          minLength: 1
+        items:
+          type: array
+          minItems: 1
           items:
-            type: array
-            minItems: 1
-            items:
-              type: object
-              properties:
-                url:
-                  oneOf:
-                    - type: string
-                      minLength: 1
-                    - type: boolean
-                      enum:
-                        - false
-                name:
-                  type: string
-                  minLength: 1
-              required:
-                - name
-                - url
-  required:
-    - groups
+            type: object
+            properties:
+              url:
+                oneOf:
+                  - type: string
+                    minLength: 1
+                  - type: boolean
+                    enum:
+                      - false
+              name:
+                type: string
+                minLength: 1
+            required:
+              - name
+              - url
+required:
+  - groups

--- a/source/_patterns/01-molecules/components/article-meta.yaml
+++ b/source/_patterns/01-molecules/components/article-meta.yaml
@@ -1,7 +1,3 @@
-assets:
-  css:
-    - article-meta.css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/01-molecules/components/article-section.yaml
+++ b/source/_patterns/01-molecules/components/article-section.yaml
@@ -20,7 +20,7 @@ properties:
     type: string
     minLength: 1
   doi:
-    $ref: ../../00-atoms/components/doi.yaml#/schema
+    $ref: ../../00-atoms/components/doi.yaml
   isFirst:
     type: boolean
     default: false

--- a/source/_patterns/01-molecules/components/article-section.yaml
+++ b/source/_patterns/01-molecules/components/article-section.yaml
@@ -1,8 +1,3 @@
-assets:
-  css:
-    - article-section.css
-    - $ref: ../../00-atoms/components/doi.yaml#/assets/css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/01-molecules/components/article-section.yaml
+++ b/source/_patterns/01-molecules/components/article-section.yaml
@@ -1,36 +1,35 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    id:
-      type: string
-      minLength: 1
-    title:
-      type: string
-      minLength: 1
-    headingLevel:
-      type: integer
-      minimum: 2
-      maximum: 6
-    hasBehaviour:
-      type: boolean
-      default: false
-    isInitiallyClosed:
-      type: boolean
-    body:
-      type: string
-      minLength: 1
-    doi:
-      $ref: ../../00-atoms/components/doi.yaml#/schema
-    isFirst:
-      type: boolean
-      default: false
-  dependencies:
-    isInitiallyClosed:
-      - hasBehaviour
-    doi:
-      - id
-  required:
-    - title
-    - headingLevel
-    - body
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  id:
+    type: string
+    minLength: 1
+  title:
+    type: string
+    minLength: 1
+  headingLevel:
+    type: integer
+    minimum: 2
+    maximum: 6
+  hasBehaviour:
+    type: boolean
+    default: false
+  isInitiallyClosed:
+    type: boolean
+  body:
+    type: string
+    minLength: 1
+  doi:
+    $ref: ../../00-atoms/components/doi.yaml#/schema
+  isFirst:
+    type: boolean
+    default: false
+dependencies:
+  isInitiallyClosed:
+    - hasBehaviour
+  doi:
+    - id
+required:
+  - title
+  - headingLevel
+  - body

--- a/source/_patterns/01-molecules/components/audio-player.yaml
+++ b/source/_patterns/01-molecules/components/audio-player.yaml
@@ -1,39 +1,38 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    title:
-      type: string
-      minLength: 1
-    url:
-      oneOf:
-        - type: string
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  title:
+    type: string
+    minLength: 1
+  url:
+    oneOf:
+      - type: string
+        minLength: 1
+      - type: boolean
+        enum:
+          - false
+  metadata:
+    type: string
+    minLength: 1
+  sources:
+    type: array
+    minItems: 1
+    items:
+      type: object
+      properties:
+        src:
+          type: string
           minLength: 1
-        - type: boolean
-          enum:
-            - false
-    metadata:
-      type: string
-      minLength: 1
-    sources:
-      type: array
-      minItems: 1
-      items:
-        type: object
-        properties:
-          src:
-            type: string
-            minLength: 1
-          mediaType:
-            type: object
-            properties:
-              forMachine:
-                type: string
-                pattern: ^(audio\/[a-zA-Z0-9!#$%^&\*_\-\+{}\|'.`~]+)(; *[a-zA-Z0-9!#$%^&\*_\-\+{}\|'.`~]+=(([a-zA-Z0-9\.\-]+)|(".+")))*$
-              forHuman:
-                type: string
-                minLength: 1
-  required:
-    - title
-    - url
-    - sources
+        mediaType:
+          type: object
+          properties:
+            forMachine:
+              type: string
+              pattern: ^(audio\/[a-zA-Z0-9!#$%^&\*_\-\+{}\|'.`~]+)(; *[a-zA-Z0-9!#$%^&\*_\-\+{}\|'.`~]+=(([a-zA-Z0-9\.\-]+)|(".+")))*$
+            forHuman:
+              type: string
+              minLength: 1
+required:
+  - title
+  - url
+  - sources

--- a/source/_patterns/01-molecules/components/audio-player.yaml
+++ b/source/_patterns/01-molecules/components/audio-player.yaml
@@ -1,7 +1,3 @@
-assets:
-  css:
-    - audio-player.css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/01-molecules/components/authors-details.yaml
+++ b/source/_patterns/01-molecules/components/authors-details.yaml
@@ -5,4 +5,4 @@ properties:
     type: array
     minItems: 1
     items:
-      $ref: ../../00-atoms/components/author-details.yaml#/schema
+      $ref: ../../00-atoms/components/author-details.yaml

--- a/source/_patterns/01-molecules/components/authors-details.yaml
+++ b/source/_patterns/01-molecules/components/authors-details.yaml
@@ -1,8 +1,3 @@
-assets:
-  css:
-    - authors-details.css
-    - $ref: ../../00-atoms/components/author-details.yaml#/assets/css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/01-molecules/components/authors-details.yaml
+++ b/source/_patterns/01-molecules/components/authors-details.yaml
@@ -1,9 +1,8 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    authorDetails:
-      type: array
-      minItems: 1
-      items:
-        $ref: ../../00-atoms/components/author-details.yaml#/schema
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  authorDetails:
+    type: array
+    minItems: 1
+    items:
+      $ref: ../../00-atoms/components/author-details.yaml#/schema

--- a/source/_patterns/01-molecules/components/bar-chart.yaml
+++ b/source/_patterns/01-molecules/components/bar-chart.yaml
@@ -1,35 +1,34 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    id:
-      type: string
-      minLength: 1
-    type:
-      type: string
-      minLength: 1
-    containerId:
-      type: string
-      minLength: 1
-    apiEndpoint:
-      type: string
-      minLength: 1
-    metric:
-      type: string
-      minLength: 1
-      enum:
-       - downloads
-       - page-views
-    period:
-      type: string
-      minLength: 1
-      enum:
-        - day
-        - month
-  required:
-    - id
-    - type
-    - metric
-    - period
-    - containerId
-    - apiEndpoint
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  id:
+    type: string
+    minLength: 1
+  type:
+    type: string
+    minLength: 1
+  containerId:
+    type: string
+    minLength: 1
+  apiEndpoint:
+    type: string
+    minLength: 1
+  metric:
+    type: string
+    minLength: 1
+    enum:
+     - downloads
+     - page-views
+  period:
+    type: string
+    minLength: 1
+    enum:
+      - day
+      - month
+required:
+  - id
+  - type
+  - metric
+  - period
+  - containerId
+  - apiEndpoint

--- a/source/_patterns/01-molecules/components/bar-chart.yaml
+++ b/source/_patterns/01-molecules/components/bar-chart.yaml
@@ -1,11 +1,3 @@
-assets:
-  css:
-    - button-collection.css
-    - chart.css
-    - tooltip.css
-    - triggers.css
-    - $ref: ../../00-atoms/components/button.yaml#/assets/css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/01-molecules/components/button-collection.yaml
+++ b/source/_patterns/01-molecules/components/button-collection.yaml
@@ -9,6 +9,6 @@ properties:
     type: array
     minItems: 1
     items:
-      $ref: ../../00-atoms/components/button.yaml#/schema
+      $ref: ../../00-atoms/components/button.yaml
 required:
   - buttons

--- a/source/_patterns/01-molecules/components/button-collection.yaml
+++ b/source/_patterns/01-molecules/components/button-collection.yaml
@@ -1,8 +1,3 @@
-assets:
-  css:
-    - button-collection.css
-    - $ref: ../../00-atoms/components/button.yaml#/assets/css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/01-molecules/components/button-collection.yaml
+++ b/source/_patterns/01-molecules/components/button-collection.yaml
@@ -1,15 +1,14 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    compact:
-      type: boolean
-    centered:
-      type: boolean
-    buttons:
-      type: array
-      minItems: 1
-      items:
-        $ref: ../../00-atoms/components/button.yaml#/schema
-  required:
-    - buttons
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  compact:
+    type: boolean
+  centered:
+    type: boolean
+  buttons:
+    type: array
+    minItems: 1
+    items:
+      $ref: ../../00-atoms/components/button.yaml#/schema
+required:
+  - buttons

--- a/source/_patterns/01-molecules/components/captioned-asset.yaml
+++ b/source/_patterns/01-molecules/components/captioned-asset.yaml
@@ -4,9 +4,9 @@ allOf:
   -
     properties:
       captionText:
-        $ref: ../../00-atoms/components/caption-text.yaml#/schema
+        $ref: ../../00-atoms/components/caption-text.yaml
       doi:
-        $ref: ../../00-atoms/components/doi.yaml#/schema
+        $ref: ../../00-atoms/components/doi.yaml
       inline:
         type: boolean
         default: false
@@ -15,19 +15,19 @@ allOf:
       -
         properties:
           picture:
-            $ref: ../../00-atoms/components/picture.yaml#/schema
+            $ref: ../../00-atoms/components/picture.yaml
         required:
           - picture
       -
         properties:
           video:
-            $ref: ../../00-atoms/components/video.yaml#/schema
+            $ref: ../../00-atoms/components/video.yaml
         required:
           - video
       -
         properties:
           table:
-            $ref: ../../00-atoms/components/table.yaml#/schema
+            $ref: ../../00-atoms/components/table.yaml
         required:
           - table
       -

--- a/source/_patterns/01-molecules/components/captioned-asset.yaml
+++ b/source/_patterns/01-molecules/components/captioned-asset.yaml
@@ -1,12 +1,3 @@
-assets:
-  css:
-    - captioned-asset.css
-    - $ref: ../../00-atoms/components/caption-text.yaml#/assets/css
-    - $ref: ../../00-atoms/components/doi.yaml#/assets/css
-    - $ref: ../../00-atoms/components/picture.yaml#/assets/css
-    - $ref: ../../00-atoms/components/video.yaml#/assets/css
-    - $ref: ../../00-atoms/components/table.yaml#/assets/css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/01-molecules/components/captioned-asset.yaml
+++ b/source/_patterns/01-molecules/components/captioned-asset.yaml
@@ -1,54 +1,53 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  allOf:
-    -
-      properties:
-        captionText:
-          $ref: ../../00-atoms/components/caption-text.yaml#/schema
-        doi:
-          $ref: ../../00-atoms/components/doi.yaml#/schema
-        inline:
-          type: boolean
-          default: false
-    -
-      oneOf:
-        -
-          properties:
-            picture:
-              $ref: ../../00-atoms/components/picture.yaml#/schema
-          required:
-            - picture
-        -
-          properties:
-            video:
-              $ref: ../../00-atoms/components/video.yaml#/schema
-          required:
-            - video
-        -
-          properties:
-            table:
-              $ref: ../../00-atoms/components/table.yaml#/schema
-          required:
-            - table
-        -
-          properties:
-            image:
-              type: object
-              properties:
-                defaultPath:
-                  type: string
-                  minLength: 1
-                altText:
-                  type: string
-                classes:
-                  type: string
-                  minLength: 1
-                srcset:
-                  type: string
-                  pattern: ^((https)?[^ ]+ [1-9][0-9.]*x, )*((https?)?[^ ]+ 1x)$
-              required:
-                - defaultPath
-                - altText
-          required:
-            - image
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+allOf:
+  -
+    properties:
+      captionText:
+        $ref: ../../00-atoms/components/caption-text.yaml#/schema
+      doi:
+        $ref: ../../00-atoms/components/doi.yaml#/schema
+      inline:
+        type: boolean
+        default: false
+  -
+    oneOf:
+      -
+        properties:
+          picture:
+            $ref: ../../00-atoms/components/picture.yaml#/schema
+        required:
+          - picture
+      -
+        properties:
+          video:
+            $ref: ../../00-atoms/components/video.yaml#/schema
+        required:
+          - video
+      -
+        properties:
+          table:
+            $ref: ../../00-atoms/components/table.yaml#/schema
+        required:
+          - table
+      -
+        properties:
+          image:
+            type: object
+            properties:
+              defaultPath:
+                type: string
+                minLength: 1
+              altText:
+                type: string
+              classes:
+                type: string
+                minLength: 1
+              srcset:
+                type: string
+                pattern: ^((https)?[^ ]+ [1-9][0-9.]*x, )*((https?)?[^ ]+ 1x)$
+            required:
+              - defaultPath
+              - altText
+        required:
+          - image

--- a/source/_patterns/01-molecules/components/carousel-item.yaml
+++ b/source/_patterns/01-molecules/components/carousel-item.yaml
@@ -1,9 +1,3 @@
-assets:
-  css:
-    - carousel-item.css
-    - $ref: ../../00-atoms/components/button.yaml#/assets/css
-    - $ref: ../../01-molecules/components/meta.yaml#/assets/css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/01-molecules/components/carousel-item.yaml
+++ b/source/_patterns/01-molecules/components/carousel-item.yaml
@@ -30,11 +30,11 @@ properties:
     type: string
     minLength: 1
   button:
-    $ref: ../../00-atoms/components/button.yaml#/schema
+    $ref: ../../00-atoms/components/button.yaml
   meta:
-    $ref: ../../01-molecules/components/meta.yaml#/schema
+    $ref: ../../01-molecules/components/meta.yaml
   image:
-    $ref: ../../00-atoms/components/picture.yaml#/schema
+    $ref: ../../00-atoms/components/picture.yaml
 required:
   - title
   - url

--- a/source/_patterns/01-molecules/components/carousel-item.yaml
+++ b/source/_patterns/01-molecules/components/carousel-item.yaml
@@ -1,43 +1,42 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    subjects:
-      type: object
-      properties:
-        list:
-          type: array
-          minItems: 1
-          items:
-            type: object
-            properties:
-              name:
-                type: string
-                minLength: 1
-              url:
-                type: string
-                minLength: 1
-            required:
-              - name
-              - url
-      required:
-        - list
-    title:
-      type: string
-      minLength: 1
-    longTitle:
-      type: boolean
-    url:
-      type: string
-      minLength: 1
-    button:
-      $ref: ../../00-atoms/components/button.yaml#/schema
-    meta:
-      $ref: ../../01-molecules/components/meta.yaml#/schema
-    image:
-      $ref: ../../00-atoms/components/picture.yaml#/schema
-  required:
-    - title
-    - url
-    - meta
-    - image
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  subjects:
+    type: object
+    properties:
+      list:
+        type: array
+        minItems: 1
+        items:
+          type: object
+          properties:
+            name:
+              type: string
+              minLength: 1
+            url:
+              type: string
+              minLength: 1
+          required:
+            - name
+            - url
+    required:
+      - list
+  title:
+    type: string
+    minLength: 1
+  longTitle:
+    type: boolean
+  url:
+    type: string
+    minLength: 1
+  button:
+    $ref: ../../00-atoms/components/button.yaml#/schema
+  meta:
+    $ref: ../../01-molecules/components/meta.yaml#/schema
+  image:
+    $ref: ../../00-atoms/components/picture.yaml#/schema
+required:
+  - title
+  - url
+  - meta
+  - image

--- a/source/_patterns/01-molecules/components/compact-form.yaml
+++ b/source/_patterns/01-molecules/components/compact-form.yaml
@@ -1,7 +1,3 @@
-assets:
-  css:
-    - compact-form.css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/01-molecules/components/compact-form.yaml
+++ b/source/_patterns/01-molecules/components/compact-form.yaml
@@ -60,9 +60,9 @@ properties:
   hiddenFields:
     type: array
     items:
-      $ref: ../../00-atoms/forms/hidden-field.yaml#/schema
+      $ref: ../../00-atoms/forms/hidden-field.yaml
   honeypot:
-    $ref: ../../00-atoms/forms/honeypot.yaml#/schema
+    $ref: ../../00-atoms/forms/honeypot.yaml
 required:
   - formId
   - formAction

--- a/source/_patterns/01-molecules/components/compact-form.yaml
+++ b/source/_patterns/01-molecules/components/compact-form.yaml
@@ -1,74 +1,73 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    formAction:
-      type: string
-      minLength: 1
-    formId:
-      type: string
-      minLength: 1
-    formMethod:
-      type: string
-      enum:
-        - GET
-        - POST
-    state:
-      type: string
-      enum:
-        - valid
-        - invalid
-    messageGroup:
-      type: object
-      properties:
-        errorText:
-          type: string
-          minLength: 1
-        infoText:
-          type: string
-          minLength: 1
-        id:
-          type: string
-          minLength: 1
-      minProperties: 2
-      required:
-        - id
-    label:
-      type: string
-      minLength: 1
-    inputType:
-      type: string
-      enum:
-        - email
-        - password
-        - search
-        - tel
-        - text
-        - url
-    inputName:
-      type: string
-      minLength: 1
-    inputValue:
-      type: string
-    inputPlaceholder:
-      type: string
-      minLength: 1
-    inputAutofocus:
-      type: boolean
-    ctaText:
-      type: string
-      minLength: 1
-    hiddenFields:
-      type: array
-      items:
-        $ref: ../../00-atoms/forms/hidden-field.yaml#/schema
-    honeypot:
-      $ref: ../../00-atoms/forms/honeypot.yaml#/schema
-  required:
-    - formId
-    - formAction
-    - formMethod
-    - label
-    - inputName
-    - inputPlaceholder
-    - ctaText
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  formAction:
+    type: string
+    minLength: 1
+  formId:
+    type: string
+    minLength: 1
+  formMethod:
+    type: string
+    enum:
+      - GET
+      - POST
+  state:
+    type: string
+    enum:
+      - valid
+      - invalid
+  messageGroup:
+    type: object
+    properties:
+      errorText:
+        type: string
+        minLength: 1
+      infoText:
+        type: string
+        minLength: 1
+      id:
+        type: string
+        minLength: 1
+    minProperties: 2
+    required:
+      - id
+  label:
+    type: string
+    minLength: 1
+  inputType:
+    type: string
+    enum:
+      - email
+      - password
+      - search
+      - tel
+      - text
+      - url
+  inputName:
+    type: string
+    minLength: 1
+  inputValue:
+    type: string
+  inputPlaceholder:
+    type: string
+    minLength: 1
+  inputAutofocus:
+    type: boolean
+  ctaText:
+    type: string
+    minLength: 1
+  hiddenFields:
+    type: array
+    items:
+      $ref: ../../00-atoms/forms/hidden-field.yaml#/schema
+  honeypot:
+    $ref: ../../00-atoms/forms/honeypot.yaml#/schema
+required:
+  - formId
+  - formAction
+  - formMethod
+  - label
+  - inputName
+  - inputPlaceholder
+  - ctaText

--- a/source/_patterns/01-molecules/components/contextual-data.yaml
+++ b/source/_patterns/01-molecules/components/contextual-data.yaml
@@ -1,9 +1,3 @@
-assets:
-  css:
-    - contextual-data.css
-    - $ref: ../../00-atoms/components/speech-bubble.yaml#/assets/css
-
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/01-molecules/components/contextual-data.yaml
+++ b/source/_patterns/01-molecules/components/contextual-data.yaml
@@ -16,7 +16,7 @@ properties:
           required:
             - text
       annotationCount:
-        $ref: ../../00-atoms/components/speech-bubble.yaml#/schema
+        $ref: ../../00-atoms/components/speech-bubble.yaml
     minProperties: 1
   citation:
     type: object
@@ -25,7 +25,7 @@ properties:
         type: string
         minLength: 1
       doi:
-        $ref: ../../00-atoms/components/doi.yaml#/schema
+        $ref: ../../00-atoms/components/doi.yaml
     required:
       - citeAs
       - doi

--- a/source/_patterns/01-molecules/components/contextual-data.yaml
+++ b/source/_patterns/01-molecules/components/contextual-data.yaml
@@ -1,33 +1,32 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    metricsData:
-      type: object
-      properties:
-        data:
-          type: array
-          minItems: 1
-          items:
-            type: object
-            properties:
-              text:
-                type: string
-                minLength: 1
-            required:
-              - text
-        annotationCount:
-          $ref: ../../00-atoms/components/speech-bubble.yaml#/schema
-      minProperties: 1
-    citation:
-      type: object
-      properties:
-        citeAs:
-          type: string
-          minLength: 1
-        doi:
-          $ref: ../../00-atoms/components/doi.yaml#/schema
-      required:
-        - citeAs
-        - doi
-  minProperties: 1
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  metricsData:
+    type: object
+    properties:
+      data:
+        type: array
+        minItems: 1
+        items:
+          type: object
+          properties:
+            text:
+              type: string
+              minLength: 1
+          required:
+            - text
+      annotationCount:
+        $ref: ../../00-atoms/components/speech-bubble.yaml#/schema
+    minProperties: 1
+  citation:
+    type: object
+    properties:
+      citeAs:
+        type: string
+        minLength: 1
+      doi:
+        $ref: ../../00-atoms/components/doi.yaml#/schema
+    required:
+      - citeAs
+      - doi
+minProperties: 1

--- a/source/_patterns/01-molecules/components/filter-group.yaml
+++ b/source/_patterns/01-molecules/components/filter-group.yaml
@@ -1,7 +1,3 @@
-assets:
-  css:
-    - filter-group.css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/01-molecules/components/filter-group.yaml
+++ b/source/_patterns/01-molecules/components/filter-group.yaml
@@ -1,35 +1,34 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    title:
-      type: string
-      minLength: 1
-    filters:
-      type: array
-      minItems: 1
-      items:
-        type: object
-        properties:
-          label:
-            type: string
-            minLength: 1
-          name:
-            type: string
-            minLength: 1
-          value:
-            type: string
-            minLength: 1
-          isChecked:
-            type: boolean
-          results:
-            type: string
-            pattern: ^(0|([1-9][0-9]{0,2}(,[0-9]{3})*))$
-        required:
-          - label
-          - name
-          - isChecked
-          - results
-  required:
-    - title
-    - filters
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  title:
+    type: string
+    minLength: 1
+  filters:
+    type: array
+    minItems: 1
+    items:
+      type: object
+      properties:
+        label:
+          type: string
+          minLength: 1
+        name:
+          type: string
+          minLength: 1
+        value:
+          type: string
+          minLength: 1
+        isChecked:
+          type: boolean
+        results:
+          type: string
+          pattern: ^(0|([1-9][0-9]{0,2}(,[0-9]{3})*))$
+      required:
+        - label
+        - name
+        - isChecked
+        - results
+required:
+  - title
+  - filters

--- a/source/_patterns/01-molecules/components/inline-profile.yaml
+++ b/source/_patterns/01-molecules/components/inline-profile.yaml
@@ -1,7 +1,3 @@
-assets:
-  css:
-    - inline-profile.css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/01-molecules/components/inline-profile.yaml
+++ b/source/_patterns/01-molecules/components/inline-profile.yaml
@@ -5,7 +5,7 @@ properties:
     type: string
     minLength: 1
   image:
-    $ref: ../../00-atoms/components/picture.yaml#/schema
+    $ref: ../../00-atoms/components/picture.yaml
 required:
   - text
   - image

--- a/source/_patterns/01-molecules/components/inline-profile.yaml
+++ b/source/_patterns/01-molecules/components/inline-profile.yaml
@@ -1,12 +1,11 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    text:
-      type: string
-      minLength: 1
-    image:
-      $ref: ../../00-atoms/components/picture.yaml#/schema
-  required:
-    - text
-    - image
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  text:
+    type: string
+    minLength: 1
+  image:
+    $ref: ../../00-atoms/components/picture.yaml#/schema
+required:
+  - text
+  - image

--- a/source/_patterns/01-molecules/components/investor-logos.yaml
+++ b/source/_patterns/01-molecules/components/investor-logos.yaml
@@ -1,11 +1,10 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    logos:
-      type: array
-      minItems: 1
-      items:
-        $ref: ../../00-atoms/components/picture.yaml#/schema
-  required:
-    - logos
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  logos:
+    type: array
+    minItems: 1
+    items:
+      $ref: ../../00-atoms/components/picture.yaml#/schema
+required:
+  - logos

--- a/source/_patterns/01-molecules/components/investor-logos.yaml
+++ b/source/_patterns/01-molecules/components/investor-logos.yaml
@@ -5,6 +5,6 @@ properties:
     type: array
     minItems: 1
     items:
-      $ref: ../../00-atoms/components/picture.yaml#/schema
+      $ref: ../../00-atoms/components/picture.yaml
 required:
   - logos

--- a/source/_patterns/01-molecules/components/investor-logos.yaml
+++ b/source/_patterns/01-molecules/components/investor-logos.yaml
@@ -1,7 +1,3 @@
-assets:
-  css:
-    - investor-logos.css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/01-molecules/components/lead-paras.yaml
+++ b/source/_patterns/01-molecules/components/lead-paras.yaml
@@ -5,6 +5,6 @@ properties:
     type: array
     minItems: 1
     items:
-      $ref: ../../00-atoms/components/lead-para.yaml#/schema
+      $ref: ../../00-atoms/components/lead-para.yaml
 required:
   - paras

--- a/source/_patterns/01-molecules/components/lead-paras.yaml
+++ b/source/_patterns/01-molecules/components/lead-paras.yaml
@@ -1,11 +1,10 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    paras:
-      type: array
-      minItems: 1
-      items:
-        $ref: ../../00-atoms/components/lead-para.yaml#/schema
-  required:
-    - paras
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  paras:
+    type: array
+    minItems: 1
+    items:
+      $ref: ../../00-atoms/components/lead-para.yaml#/schema
+required:
+  - paras

--- a/source/_patterns/01-molecules/components/lead-paras.yaml
+++ b/source/_patterns/01-molecules/components/lead-paras.yaml
@@ -1,8 +1,3 @@
-assets:
-  css:
-    - lead-paras.css
-    - $ref: ../../00-atoms/components/lead-para.yaml#/assets/css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/01-molecules/components/media-chapter-listing-item.yaml
+++ b/source/_patterns/01-molecules/components/media-chapter-listing-item.yaml
@@ -1,59 +1,58 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    startTime:
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  startTime:
+    type: object
+    properties:
+      forMachine:
+        type: integer
+        minValue: 0
+      forHuman:
+        type: string
+        pattern: ^([1-9][0-9]*|0):[0-5][0-9]$
+  chapterNumber:
+    type: integer
+    minValue: 1
+  title:
+    type: string
+    minLength: 1
+  content:
+    type: string
+    minLength: 1
+  hasContentSources:
+    type: boolean
+    enum:
+      - true
+  contentSources:
+    type: array
+    items:
       type: object
       properties:
-        forMachine:
-          type: integer
-          minValue: 0
-        forHuman:
+        contentType:
+          type: object
+          properties:
+            url:
+              type: string
+              minLength: 1
+            name:
+              type: string
+              minLength: 1
+          required:
+            - url
+            - name
+        text:
           type: string
-          pattern: ^([1-9][0-9]*|0):[0-5][0-9]$
-    chapterNumber:
-      type: integer
-      minValue: 1
-    title:
-      type: string
-      minLength: 1
-    content:
-      type: string
-      minLength: 1
-    hasContentSources:
-      type: boolean
-      enum:
-        - true
-    contentSources:
-      type: array
-      items:
-        type: object
-        properties:
-          contentType:
-            type: object
-            properties:
-              url:
-                type: string
-                minLength: 1
-              name:
-                type: string
-                minLength: 1
-            required:
-              - url
-              - name
-          text:
-            type: string
-        required:
-          - contentType
-      minItems: 1
+      required:
+        - contentType
+    minItems: 1
 
-  dependencies:
-    chapterNumber:
-      - startTime
-    hasContentSources:
-      - contentSources
-    contentSources:
-      - hasContentSources
-  required:
-    - title
+dependencies:
+  chapterNumber:
+    - startTime
+  hasContentSources:
+    - contentSources
+  contentSources:
+    - hasContentSources
+required:
+  - title
 

--- a/source/_patterns/01-molecules/components/media-chapter-listing-item.yaml
+++ b/source/_patterns/01-molecules/components/media-chapter-listing-item.yaml
@@ -1,7 +1,3 @@
-assets:
-  css:
-    - media-chapter-listing-item.css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/01-molecules/components/meta.yaml
+++ b/source/_patterns/01-molecules/components/meta.yaml
@@ -1,27 +1,26 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    url:
-      oneOf:
-        - type: string
-          minLength: 1
-        - type: boolean
-          enum:
-            - false
-    carouselItem:
-      type: boolean
-      enum:
-        - true
-    text:
-      type: string
-      minLength: 1
-    date:
-      $ref: ../../00-atoms/components/date.yaml#/schema
-  anyOf:
-    -
-      required:
-        - date
-    -
-      required:
-        - text
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  url:
+    oneOf:
+      - type: string
+        minLength: 1
+      - type: boolean
+        enum:
+          - false
+  carouselItem:
+    type: boolean
+    enum:
+      - true
+  text:
+    type: string
+    minLength: 1
+  date:
+    $ref: ../../00-atoms/components/date.yaml#/schema
+anyOf:
+  -
+    required:
+      - date
+  -
+    required:
+      - text

--- a/source/_patterns/01-molecules/components/meta.yaml
+++ b/source/_patterns/01-molecules/components/meta.yaml
@@ -16,7 +16,7 @@ properties:
     type: string
     minLength: 1
   date:
-    $ref: ../../00-atoms/components/date.yaml#/schema
+    $ref: ../../00-atoms/components/date.yaml
 anyOf:
   -
     required:

--- a/source/_patterns/01-molecules/components/meta.yaml
+++ b/source/_patterns/01-molecules/components/meta.yaml
@@ -1,8 +1,3 @@
-assets:
-  css:
-    - meta.css
-    - $ref: ../../00-atoms/components/date.yaml#/assets/css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/01-molecules/components/mini-section.yaml
+++ b/source/_patterns/01-molecules/components/mini-section.yaml
@@ -3,7 +3,7 @@ type: object
 properties:
   listHeading:
     type: object
-    $ref: ../../00-atoms/components/list-heading.yaml#/schema
+    $ref: ../../00-atoms/components/list-heading.yaml
   body:
     type: string
     minLength: 1

--- a/source/_patterns/01-molecules/components/mini-section.yaml
+++ b/source/_patterns/01-molecules/components/mini-section.yaml
@@ -1,12 +1,11 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    listHeading:
-      type: object
-      $ref: ../../00-atoms/components/list-heading.yaml#/schema
-    body:
-      type: string
-      minLength: 1
-  required:
-    - body
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  listHeading:
+    type: object
+    $ref: ../../00-atoms/components/list-heading.yaml#/schema
+  body:
+    type: string
+    minLength: 1
+required:
+  - body

--- a/source/_patterns/01-molecules/components/mini-section.yaml
+++ b/source/_patterns/01-molecules/components/mini-section.yaml
@@ -1,8 +1,3 @@
-assets:
-  css:
-    - mini-section.css
-    - $ref: ../../00-atoms/components/list-heading.yaml#/assets/css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/01-molecules/components/personalised-cover-download.yaml
+++ b/source/_patterns/01-molecules/components/personalised-cover-download.yaml
@@ -1,9 +1,3 @@
-assets:
-  css:
-    - personalised-cover-download.css
-    - $ref: ../../00-atoms/components/paragraph.yaml#/assets/css
-    - $ref: button-collection.yaml#/assets/css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/01-molecules/components/personalised-cover-download.yaml
+++ b/source/_patterns/01-molecules/components/personalised-cover-download.yaml
@@ -1,14 +1,13 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    text:
-      type: array
-      items:
-        $ref: ../../00-atoms/components/paragraph.yaml#/schema
-      minItems: 1
-    buttonCollection:
-      $ref: button-collection.yaml#/schema
-  required:
-    - text
-    - buttonCollection
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  text:
+    type: array
+    items:
+      $ref: ../../00-atoms/components/paragraph.yaml#/schema
+    minItems: 1
+  buttonCollection:
+    $ref: button-collection.yaml#/schema
+required:
+  - text
+  - buttonCollection

--- a/source/_patterns/01-molecules/components/personalised-cover-download.yaml
+++ b/source/_patterns/01-molecules/components/personalised-cover-download.yaml
@@ -4,10 +4,10 @@ properties:
   text:
     type: array
     items:
-      $ref: ../../00-atoms/components/paragraph.yaml#/schema
+      $ref: ../../00-atoms/components/paragraph.yaml
     minItems: 1
   buttonCollection:
-    $ref: button-collection.yaml#/schema
+    $ref: button-collection.yaml
 required:
   - text
   - buttonCollection

--- a/source/_patterns/01-molecules/components/profile-snippet.yaml
+++ b/source/_patterns/01-molecules/components/profile-snippet.yaml
@@ -1,18 +1,17 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    title:
-      type: string
-      minLength: 1
-    name:
-      type: string
-      minLength: 1
-    contactDetails:
-      type: string
-      minLength: 1
-    image:
-      $ref: ../../00-atoms/components/picture.yaml#/schema
-  required:
-    - title
-    - name
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  title:
+    type: string
+    minLength: 1
+  name:
+    type: string
+    minLength: 1
+  contactDetails:
+    type: string
+    minLength: 1
+  image:
+    $ref: ../../00-atoms/components/picture.yaml#/schema
+required:
+  - title
+  - name

--- a/source/_patterns/01-molecules/components/profile-snippet.yaml
+++ b/source/_patterns/01-molecules/components/profile-snippet.yaml
@@ -11,7 +11,7 @@ properties:
     type: string
     minLength: 1
   image:
-    $ref: ../../00-atoms/components/picture.yaml#/schema
+    $ref: ../../00-atoms/components/picture.yaml
 required:
   - title
   - name

--- a/source/_patterns/01-molecules/components/profile-snippet.yaml
+++ b/source/_patterns/01-molecules/components/profile-snippet.yaml
@@ -1,7 +1,3 @@
-assets:
-  css:
-    - profile-snippet.css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/01-molecules/components/pull-quote.yaml
+++ b/source/_patterns/01-molecules/components/pull-quote.yaml
@@ -1,12 +1,11 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    quote:
-      type: string
-      minLength: 1
-    cite:
-      type: string
-      minLength: 1
-  required:
-    - quote
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  quote:
+    type: string
+    minLength: 1
+  cite:
+    type: string
+    minLength: 1
+required:
+  - quote

--- a/source/_patterns/01-molecules/components/pull-quote.yaml
+++ b/source/_patterns/01-molecules/components/pull-quote.yaml
@@ -1,7 +1,3 @@
-assets:
-  css:
-    - pull-quote.css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/01-molecules/components/quote.yaml
+++ b/source/_patterns/01-molecules/components/quote.yaml
@@ -1,12 +1,11 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    quote:
-      type: string
-      minLength: 1
-    cite:
-      type: string
-      minLength: 1
-  required:
-    - quote
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  quote:
+    type: string
+    minLength: 1
+  cite:
+    type: string
+    minLength: 1
+required:
+  - quote

--- a/source/_patterns/01-molecules/components/quote.yaml
+++ b/source/_patterns/01-molecules/components/quote.yaml
@@ -1,7 +1,3 @@
-assets:
-  css:
-    - quote.css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/01-molecules/components/reference-list.yaml
+++ b/source/_patterns/01-molecules/components/reference-list.yaml
@@ -1,8 +1,3 @@
-assets:
-  css:
-    - reference-list.css
-    - $ref: ../../00-atoms/references/reference.yaml#/assets/css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/01-molecules/components/reference-list.yaml
+++ b/source/_patterns/01-molecules/components/reference-list.yaml
@@ -20,7 +20,7 @@ properties:
             - full
             - ordinal
         reference:
-          $ref: ../../00-atoms/references/reference.yaml#/schema
+          $ref: ../../00-atoms/references/reference.yaml
       required:
         - bibId
         - reference

--- a/source/_patterns/01-molecules/components/reference-list.yaml
+++ b/source/_patterns/01-molecules/components/reference-list.yaml
@@ -1,27 +1,26 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    references:
-      type: array
-      minItems: 1
-      items:
-        type: object
-        properties:
-          bibId:
-            type: object
-            properties:
-              full:
-                type: string
-                minLength: 1
-              ordinal:
-                type: integer
-                minimum: 1
-            required:
-              - full
-              - ordinal
-          reference:
-            $ref: ../../00-atoms/references/reference.yaml#/schema
-        required:
-          - bibId
-          - reference
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  references:
+    type: array
+    minItems: 1
+    items:
+      type: object
+      properties:
+        bibId:
+          type: object
+          properties:
+            full:
+              type: string
+              minLength: 1
+            ordinal:
+              type: integer
+              minimum: 1
+          required:
+            - full
+            - ordinal
+        reference:
+          $ref: ../../00-atoms/references/reference.yaml#/schema
+      required:
+        - bibId
+        - reference

--- a/source/_patterns/01-molecules/components/search-box.yaml
+++ b/source/_patterns/01-molecules/components/search-box.yaml
@@ -1,26 +1,25 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    compactForm:
-      $ref: compact-form.yaml#/schema
-    subjectFilter:
-      type: object
-      properties:
-        name:
-          type: string
-          minLength: 1
-        value:
-          type: string
-          minLength: 1
-        text:
-          type: string
-          minLength: 1
-      required:
-        - name
-        - value
-        - text
-    inContentHeader:
-      type: boolean
-  required:
-    - compactForm
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  compactForm:
+    $ref: compact-form.yaml#/schema
+  subjectFilter:
+    type: object
+    properties:
+      name:
+        type: string
+        minLength: 1
+      value:
+        type: string
+        minLength: 1
+      text:
+        type: string
+        minLength: 1
+    required:
+      - name
+      - value
+      - text
+  inContentHeader:
+    type: boolean
+required:
+  - compactForm

--- a/source/_patterns/01-molecules/components/search-box.yaml
+++ b/source/_patterns/01-molecules/components/search-box.yaml
@@ -1,9 +1,3 @@
-assets:
-  css:
-    - search-box.css
-    - $ref: compact-form.yaml#/assets/css
-  js:
-    - $ref: compact-form.yaml#/assets/js
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/01-molecules/components/search-box.yaml
+++ b/source/_patterns/01-molecules/components/search-box.yaml
@@ -2,7 +2,7 @@ $schema: http://json-schema.org/draft-04/schema#
 type: object
 properties:
   compactForm:
-    $ref: compact-form.yaml#/schema
+    $ref: compact-form.yaml
   subjectFilter:
     type: object
     properties:

--- a/source/_patterns/01-molecules/components/section-listing.yaml
+++ b/source/_patterns/01-molecules/components/section-listing.yaml
@@ -1,35 +1,34 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    id:
-      type: string
-      minLength: 1
-    singleLine:
-      type: boolean
-    labelledBy:
-      type: string
-      minLength: 1
-    listHeading:
-      $ref: ../../00-atoms/components/list-heading.yaml#/schema
-    sections:
-      type: array
-      minItems: 1
-      items:
-        type: object
-        properties:
-          url:
-            type: string
-            minLength: 1
-          name:
-            type: string
-            minLength: 1
-          isCurrent:
-            type: boolean
-        required:
-          - url
-          - name
-  required:
-    - id
-    - sections
-    - listHeading
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  id:
+    type: string
+    minLength: 1
+  singleLine:
+    type: boolean
+  labelledBy:
+    type: string
+    minLength: 1
+  listHeading:
+    $ref: ../../00-atoms/components/list-heading.yaml#/schema
+  sections:
+    type: array
+    minItems: 1
+    items:
+      type: object
+      properties:
+        url:
+          type: string
+          minLength: 1
+        name:
+          type: string
+          minLength: 1
+        isCurrent:
+          type: boolean
+      required:
+        - url
+        - name
+required:
+  - id
+  - sections
+  - listHeading

--- a/source/_patterns/01-molecules/components/section-listing.yaml
+++ b/source/_patterns/01-molecules/components/section-listing.yaml
@@ -10,7 +10,7 @@ properties:
     type: string
     minLength: 1
   listHeading:
-    $ref: ../../00-atoms/components/list-heading.yaml#/schema
+    $ref: ../../00-atoms/components/list-heading.yaml
   sections:
     type: array
     minItems: 1

--- a/source/_patterns/01-molecules/components/section-listing.yaml
+++ b/source/_patterns/01-molecules/components/section-listing.yaml
@@ -1,8 +1,3 @@
-assets:
-  css:
-    - section-listing.css
-    - $ref: ../../00-atoms/components/list-heading.yaml#/assets/css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/01-molecules/components/sort-control.yaml
+++ b/source/_patterns/01-molecules/components/sort-control.yaml
@@ -1,27 +1,26 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    options:
-      type: array
-      minItems: 1
-      items:
-        type: object
-        properties:
-          option:
-            type: string
-            minLength: 1
-          sorting:
-            type: string
-            minLength: 1
-            enum:
-              - ascending
-              - descending
-          url:
-            type: string
-            minLength: 1
-        required:
-          - option
-          - url
-  required:
-    - options
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  options:
+    type: array
+    minItems: 1
+    items:
+      type: object
+      properties:
+        option:
+          type: string
+          minLength: 1
+        sorting:
+          type: string
+          minLength: 1
+          enum:
+            - ascending
+            - descending
+        url:
+          type: string
+          minLength: 1
+      required:
+        - option
+        - url
+required:
+  - options

--- a/source/_patterns/01-molecules/components/sort-control.yaml
+++ b/source/_patterns/01-molecules/components/sort-control.yaml
@@ -1,7 +1,3 @@
-assets:
-  css:
-    - sort-control.css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/01-molecules/components/statistic.yaml
+++ b/source/_patterns/01-molecules/components/statistic.yaml
@@ -1,13 +1,12 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    label:
-      type: string
-      minLength: 1
-    value:
-      type: string
-      minLength: 1
-  required:
-    - label
-    - value
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  label:
+    type: string
+    minLength: 1
+  value:
+    type: string
+    minLength: 1
+required:
+  - label
+  - value

--- a/source/_patterns/01-molecules/components/statistic.yaml
+++ b/source/_patterns/01-molecules/components/statistic.yaml
@@ -1,7 +1,3 @@
-assets:
-  css:
-    - statistic.css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/01-molecules/navigation/login-control.yaml
+++ b/source/_patterns/01-molecules/navigation/login-control.yaml
@@ -1,45 +1,44 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  oneOf:
-    - properties:
-        button:
-          $ref: ../../00-atoms/components/button.yaml#/schema
-      required:
-        - button
-    - properties:
-        isLoggedIn:
-          type: boolean
-          enum:
-            - true
-        defaultUri:
-          type: string
-          minLength: 1
-        displayName:
-          type: string
-          minLength: 1
-        subsidiaryText:
-          type: string
-          minLength: 1
-        icon:
-          $ref: ../../00-atoms/components/picture.yaml#/schema
-        linkFieldRoots:
-          type: string
-    #      linkFieldRoots is a list of one or more words that are comma-separated. The regex:
-    #       - allows lower case js name characters, plus space, hyphen and commma
-    #       - allows leading/trailing space
-    #       - allows other space only when adjacent to a comma
-    #       - disallows leading/trailing commas and hyphens on the string
-    #       - disallows leading or trailing hyphens on a word
-          pattern: ^[ \t]*[a-z][a-z-$_]*[^-,][ \t]*(,[ \t]*[a-z][a-z-$_]*[^-,][ \t]*)*$
-        linkFieldData:
-          type: string
-          minLength: 1
-      required:
-        - isLoggedIn
-        - defaultUri
-        - displayName
-        - icon
-      dependencies:
-        linkFieldRoots: [linkFieldData]
-        linkFieldData: [linkFieldRoots]
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+oneOf:
+  - properties:
+      button:
+        $ref: ../../00-atoms/components/button.yaml#/schema
+    required:
+      - button
+  - properties:
+      isLoggedIn:
+        type: boolean
+        enum:
+          - true
+      defaultUri:
+        type: string
+        minLength: 1
+      displayName:
+        type: string
+        minLength: 1
+      subsidiaryText:
+        type: string
+        minLength: 1
+      icon:
+        $ref: ../../00-atoms/components/picture.yaml#/schema
+      linkFieldRoots:
+        type: string
+  #      linkFieldRoots is a list of one or more words that are comma-separated. The regex:
+  #       - allows lower case js name characters, plus space, hyphen and commma
+  #       - allows leading/trailing space
+  #       - allows other space only when adjacent to a comma
+  #       - disallows leading/trailing commas and hyphens on the string
+  #       - disallows leading or trailing hyphens on a word
+        pattern: ^[ \t]*[a-z][a-z-$_]*[^-,][ \t]*(,[ \t]*[a-z][a-z-$_]*[^-,][ \t]*)*$
+      linkFieldData:
+        type: string
+        minLength: 1
+    required:
+      - isLoggedIn
+      - defaultUri
+      - displayName
+      - icon
+    dependencies:
+      linkFieldRoots: [linkFieldData]
+      linkFieldData: [linkFieldRoots]

--- a/source/_patterns/01-molecules/navigation/login-control.yaml
+++ b/source/_patterns/01-molecules/navigation/login-control.yaml
@@ -1,8 +1,3 @@
-assets:
-  css:
-    - login-control.css
-    - $ref: ../../00-atoms/components/button.yaml#/assets/css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/01-molecules/navigation/login-control.yaml
+++ b/source/_patterns/01-molecules/navigation/login-control.yaml
@@ -3,7 +3,7 @@ type: object
 oneOf:
   - properties:
       button:
-        $ref: ../../00-atoms/components/button.yaml#/schema
+        $ref: ../../00-atoms/components/button.yaml
     required:
       - button
   - properties:
@@ -21,7 +21,7 @@ oneOf:
         type: string
         minLength: 1
       icon:
-        $ref: ../../00-atoms/components/picture.yaml#/schema
+        $ref: ../../00-atoms/components/picture.yaml
       linkFieldRoots:
         type: string
   #      linkFieldRoots is a list of one or more words that are comma-separated. The regex:

--- a/source/_patterns/01-molecules/navigation/main-menu.yaml
+++ b/source/_patterns/01-molecules/navigation/main-menu.yaml
@@ -1,8 +1,3 @@
-assets:
-  css:
-    - main-menu.css
-    - $ref: ../../00-atoms/components/list-heading.yaml#/assets/css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/01-molecules/navigation/main-menu.yaml
+++ b/source/_patterns/01-molecules/navigation/main-menu.yaml
@@ -20,7 +20,7 @@ properties:
     required:
       - items
   listHeading:
-    $ref: ../../00-atoms/components/list-heading.yaml#/schema
+    $ref: ../../00-atoms/components/list-heading.yaml
 required:
   - links
   - listHeading

--- a/source/_patterns/01-molecules/navigation/main-menu.yaml
+++ b/source/_patterns/01-molecules/navigation/main-menu.yaml
@@ -1,27 +1,26 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    links:
-      type: object
-      properties:
-        items:
-          type: array
-          properties:
-            name:
-              type: string
-              minLength: 1
-            url:
-              type: string
-              minLength: 1
-          required:
-            - name
-            - url
-          minItems: 1
-      required:
-        - items
-    listHeading:
-      $ref: ../../00-atoms/components/list-heading.yaml#/schema
-  required:
-    - links
-    - listHeading
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  links:
+    type: object
+    properties:
+      items:
+        type: array
+        properties:
+          name:
+            type: string
+            minLength: 1
+          url:
+            type: string
+            minLength: 1
+        required:
+          - name
+          - url
+        minItems: 1
+    required:
+      - items
+  listHeading:
+    $ref: ../../00-atoms/components/list-heading.yaml#/schema
+required:
+  - links
+  - listHeading

--- a/source/_patterns/01-molecules/navigation/pager.yaml
+++ b/source/_patterns/01-molecules/navigation/pager.yaml
@@ -2,9 +2,9 @@ $schema: http://json-schema.org/draft-04/schema#
 type: object
 properties:
   previousPage:
-    $ref: ../../00-atoms/components/button.yaml#/schema
+    $ref: ../../00-atoms/components/button.yaml
   nextPage:
-    $ref: ../../00-atoms/components/button.yaml#/schema
+    $ref: ../../00-atoms/components/button.yaml
   targetId:
     type: string
     minLength: 1

--- a/source/_patterns/01-molecules/navigation/pager.yaml
+++ b/source/_patterns/01-molecules/navigation/pager.yaml
@@ -1,16 +1,15 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    previousPage:
-      $ref: ../../00-atoms/components/button.yaml#/schema
-    nextPage:
-      $ref: ../../00-atoms/components/button.yaml#/schema
-    targetId:
-      type: string
-      minLength: 1
-  anyOf:
-    - required:
-      - nextPage
-    - required:
-      - previousPage
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  previousPage:
+    $ref: ../../00-atoms/components/button.yaml#/schema
+  nextPage:
+    $ref: ../../00-atoms/components/button.yaml#/schema
+  targetId:
+    type: string
+    minLength: 1
+anyOf:
+  - required:
+    - nextPage
+  - required:
+    - previousPage

--- a/source/_patterns/01-molecules/navigation/pager.yaml
+++ b/source/_patterns/01-molecules/navigation/pager.yaml
@@ -1,8 +1,3 @@
-assets:
-  css:
-    - pager.css
-    - $ref: ../../00-atoms/components/button.yaml#/assets/css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/01-molecules/navigation/select-nav.yaml
+++ b/source/_patterns/01-molecules/navigation/select-nav.yaml
@@ -2,12 +2,12 @@ $schema: http://json-schema.org/draft-04/schema#
 type: object
 properties:
   select:
-    $ref: ../../00-atoms/forms/select.yaml#/schema
+    $ref: ../../00-atoms/forms/select.yaml
   route:
     type: string
     minLength: 1
   button:
-    $ref: ../../00-atoms/components/button.yaml#/schema
+    $ref: ../../00-atoms/components/button.yaml
 required:
   - select
   - route

--- a/source/_patterns/01-molecules/navigation/select-nav.yaml
+++ b/source/_patterns/01-molecules/navigation/select-nav.yaml
@@ -1,9 +1,3 @@
-assets:
-  css:
-    - select-nav.css
-    - $ref: ../../00-atoms/components/button.yaml#/assets/css
-    - $ref: ../../00-atoms/forms/select.yaml#/assets/css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/01-molecules/navigation/select-nav.yaml
+++ b/source/_patterns/01-molecules/navigation/select-nav.yaml
@@ -1,15 +1,14 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    select:
-      $ref: ../../00-atoms/forms/select.yaml#/schema
-    route:
-      type: string
-      minLength: 1
-    button:
-      $ref: ../../00-atoms/components/button.yaml#/schema
-  required:
-    - select
-    - route
-    - button
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  select:
+    $ref: ../../00-atoms/forms/select.yaml#/schema
+  route:
+    type: string
+    minLength: 1
+  button:
+    $ref: ../../00-atoms/components/button.yaml#/schema
+required:
+  - select
+  - route
+  - button

--- a/source/_patterns/01-molecules/navigation/site-header-nav-bar.yaml
+++ b/source/_patterns/01-molecules/navigation/site-header-nav-bar.yaml
@@ -1,15 +1,14 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    classesOuter:
-      type: string
-    classesInner:
-      type: string
-    linkedItems:
-      type: array
-      items:
-        $ref: ../../00-atoms/components/nav-linked-item.yaml#/schema
-      minItems: 1
-  required:
-    - linkedItems
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  classesOuter:
+    type: string
+  classesInner:
+    type: string
+  linkedItems:
+    type: array
+    items:
+      $ref: ../../00-atoms/components/nav-linked-item.yaml#/schema
+    minItems: 1
+required:
+  - linkedItems

--- a/source/_patterns/01-molecules/navigation/site-header-nav-bar.yaml
+++ b/source/_patterns/01-molecules/navigation/site-header-nav-bar.yaml
@@ -1,9 +1,3 @@
-assets:
-  css:
-    - site-header-nav-bar-primary.css
-    - site-header-nav-bar-secondary.css
-    - $ref: ../../00-atoms/components/button.yaml#/assets/css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/01-molecules/navigation/site-header-nav-bar.yaml
+++ b/source/_patterns/01-molecules/navigation/site-header-nav-bar.yaml
@@ -8,7 +8,7 @@ properties:
   linkedItems:
     type: array
     items:
-      $ref: ../../00-atoms/components/nav-linked-item.yaml#/schema
+      $ref: ../../00-atoms/components/nav-linked-item.yaml
     minItems: 1
 required:
   - linkedItems

--- a/source/_patterns/01-molecules/navigation/view-selector.yaml
+++ b/source/_patterns/01-molecules/navigation/view-selector.yaml
@@ -1,38 +1,37 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    sideBySideUrl:
-      type: string
-      minLength: 1
-    articleUrl:
-      type: string
-      minLength: 1
-    figureUrl:
-      type: string
-      minLength: 1
-    figureIsActive:
-      type: boolean
-      default: false
-    jumpLinks:
-      type: object
-      properties:
-        links:
-          type: array
-          minItems: 2
-          items:
-            type: object
-            properties:
-              name:
-                type: string
-                minLength: 1
-              url:
-                type: string
-                minLength: 1
-            required:
-              - name
-              - url
-      required:
-        - links
-  required:
-    - articleUrl
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  sideBySideUrl:
+    type: string
+    minLength: 1
+  articleUrl:
+    type: string
+    minLength: 1
+  figureUrl:
+    type: string
+    minLength: 1
+  figureIsActive:
+    type: boolean
+    default: false
+  jumpLinks:
+    type: object
+    properties:
+      links:
+        type: array
+        minItems: 2
+        items:
+          type: object
+          properties:
+            name:
+              type: string
+              minLength: 1
+            url:
+              type: string
+              minLength: 1
+          required:
+            - name
+            - url
+    required:
+      - links
+required:
+  - articleUrl

--- a/source/_patterns/01-molecules/navigation/view-selector.yaml
+++ b/source/_patterns/01-molecules/navigation/view-selector.yaml
@@ -1,7 +1,3 @@
-assets:
-  css:
-    - view-selector.css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/01-molecules/teasers/annotation-teaser.yaml
+++ b/source/_patterns/01-molecules/teasers/annotation-teaser.yaml
@@ -1,8 +1,3 @@
-assets:
-  css:
-    - annotation-teaser.css
-    - $ref: ../../01-molecules/components/meta.yaml#/assets/css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/01-molecules/teasers/annotation-teaser.yaml
+++ b/source/_patterns/01-molecules/teasers/annotation-teaser.yaml
@@ -5,7 +5,7 @@ properties:
     type: string
     minLength: 1
   meta:
-    $ref: ../../01-molecules/components/meta.yaml#/schema
+    $ref: ../../01-molecules/components/meta.yaml
   inContextUri:
     minLength: 1
     type: string

--- a/source/_patterns/01-molecules/teasers/annotation-teaser.yaml
+++ b/source/_patterns/01-molecules/teasers/annotation-teaser.yaml
@@ -1,56 +1,55 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    document:
-      type: string
-      minLength: 1
-    meta:
-      $ref: ../../01-molecules/components/meta.yaml#/schema
-    inContextUri:
-      minLength: 1
-      type: string
-    highlight:
-      type: string
-      minLength: 1
-    isReply:
-      type: boolean
-      emum:
-        - true
-    content:
-      type: string
-      minLength: 1
-  required:
-    - document
-    - meta
-    - inContextUri
-  allOf:
-    - anyOf:
-      - required:
-        - highlight
-        not:
-          required:
-            - isReply
-      - required:
-        - isReply
-        not:
-          required:
-            - highlight
-      - not:
-          required:
-            - isReply
-            - highlight
-    - anyOf:
-      - required:
-        - highlight
-        not:
-          required:
-            - content
-      - required:
-        - content
-        not:
-          required:
-            - highlight
-      - required:
-        - content
-        - highlight
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  document:
+    type: string
+    minLength: 1
+  meta:
+    $ref: ../../01-molecules/components/meta.yaml#/schema
+  inContextUri:
+    minLength: 1
+    type: string
+  highlight:
+    type: string
+    minLength: 1
+  isReply:
+    type: boolean
+    emum:
+      - true
+  content:
+    type: string
+    minLength: 1
+required:
+  - document
+  - meta
+  - inContextUri
+allOf:
+  - anyOf:
+    - required:
+      - highlight
+      not:
+        required:
+          - isReply
+    - required:
+      - isReply
+      not:
+        required:
+          - highlight
+    - not:
+        required:
+          - isReply
+          - highlight
+  - anyOf:
+    - required:
+      - highlight
+      not:
+        required:
+          - content
+    - required:
+      - content
+      not:
+        required:
+          - highlight
+    - required:
+      - content
+      - highlight

--- a/source/_patterns/01-molecules/teasers/teaser.yaml
+++ b/source/_patterns/01-molecules/teasers/teaser.yaml
@@ -46,7 +46,7 @@ properties:
     type: string
     minLength: 1
   eventDate:
-    $ref: ../../00-atoms/components/date.yaml#/schema
+    $ref: ../../00-atoms/components/date.yaml
   content:
     type: string
     minLength: 1
@@ -68,7 +68,7 @@ properties:
       - url
   image:
     allOf:
-      - $ref: ../../00-atoms/components/picture.yaml#/schema
+      - $ref: ../../00-atoms/components/picture.yaml
       - properties:
           type:
             type: string
@@ -82,7 +82,7 @@ properties:
     type: object
     properties:
       meta:
-        $ref: ../../01-molecules/components/meta.yaml#/schema
+        $ref: ../../01-molecules/components/meta.yaml
       formats:
         type: object
         minProperties: 1

--- a/source/_patterns/01-molecules/teasers/teaser.yaml
+++ b/source/_patterns/01-molecules/teasers/teaser.yaml
@@ -1,108 +1,107 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    rootClasses:
-      type: string
-      minLength: 1
-    contextLabel:
-      type: object
-      properties:
-        list:
-          type: array
-          minItems: 1
-          item:
-            type: object
-            properties:
-              name:
-                type: string
-                minLength: 1
-              url:
-                oneOf:
-                  - type: string
-                    minLength: 1
-                  - type: boolean
-                    enum:
-                      - false
-            required:
-              - name
-              - url
-    url:
-      oneOf:
-        - type: string
-          minLength: 1
-        - type: boolean
-          enum:
-            - false
-    title:
-      type: string
-      minLength: 1
-    num:
-      type: integer
-      minimum: 1
-    carouselItem:
-      type: boolean
-      default: false
-    secondaryInfo:
-      type: string
-      minLength: 1
-    eventDate:
-      $ref: ../../00-atoms/components/date.yaml#/schema
-    content:
-      type: string
-      minLength: 1
-    category:
-      type: object
-      properties:
-        name:
-          type: string
-          minLength: 1
-        url:
-          oneOf:
-            - type: string
-              minLength: 1
-            - type: boolean
-              enum:
-                - false
-      required:
-        - name
-        - url
-    image:
-      allOf:
-        - $ref: ../../00-atoms/components/picture.yaml#/schema
-        - properties:
-            type:
-              type: string
-              enum:
-                - prominent
-                - big
-                - small
-          required:
-            - type
-    footer:
-      type: object
-      properties:
-        meta:
-          $ref: ../../01-molecules/components/meta.yaml#/schema
-        formats:
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  rootClasses:
+    type: string
+    minLength: 1
+  contextLabel:
+    type: object
+    properties:
+      list:
+        type: array
+        minItems: 1
+        item:
           type: object
-          minProperties: 1
           properties:
-            html:
-              type: boolean
-            pdf:
-              type: boolean
-      required:
-        - meta
+            name:
+              type: string
+              minLength: 1
+            url:
+              oneOf:
+                - type: string
+                  minLength: 1
+                - type: boolean
+                  enum:
+                    - false
+          required:
+            - name
+            - url
+  url:
+    oneOf:
+      - type: string
+        minLength: 1
+      - type: boolean
+        enum:
+          - false
+  title:
+    type: string
+    minLength: 1
+  num:
+    type: integer
+    minimum: 1
+  carouselItem:
+    type: boolean
+    default: false
+  secondaryInfo:
+    type: string
+    minLength: 1
+  eventDate:
+    $ref: ../../00-atoms/components/date.yaml#/schema
+  content:
+    type: string
+    minLength: 1
+  category:
+    type: object
+    properties:
+      name:
+        type: string
+        minLength: 1
+      url:
+        oneOf:
+          - type: string
+            minLength: 1
+          - type: boolean
+            enum:
+              - false
+    required:
+      - name
+      - url
+  image:
+    allOf:
+      - $ref: ../../00-atoms/components/picture.yaml#/schema
+      - properties:
+          type:
+            type: string
+            enum:
+              - prominent
+              - big
+              - small
+        required:
+          - type
+  footer:
+    type: object
+    properties:
+      meta:
+        $ref: ../../01-molecules/components/meta.yaml#/schema
+      formats:
+        type: object
+        minProperties: 1
+        properties:
+          html:
+            type: boolean
+          pdf:
+            type: boolean
+    required:
+      - meta
 
-  dependencies:
-    num:
-      - carouselItem
-    carouselItem:
-      - num
+dependencies:
+  num:
+    - carouselItem
+  carouselItem:
+    - num
 
-  required:
-    - title
-    - url
-    # - footer # Not in teaser~50-secondary-event.json or teaser~45-main-event.json
-    # - contextLabel # Not in teaser~60-grid-style--podcast.json or teaser~55-grid-style--labs.json or teaser~40-basic.json
+required:
+  - title
+  - url
+  # - footer # Not in teaser~50-secondary-event.json or teaser~45-main-event.json
+  # - contextLabel # Not in teaser~60-grid-style--podcast.json or teaser~55-grid-style--labs.json or teaser~40-basic.json

--- a/source/_patterns/01-molecules/teasers/teaser.yaml
+++ b/source/_patterns/01-molecules/teasers/teaser.yaml
@@ -1,8 +1,3 @@
-assets:
-  css:
-    - teaser.css
-    - $ref: ../../01-molecules/components/meta.yaml#/assets/css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/02-organisms/asset-viewer/asset-viewer-inline.yaml
+++ b/source/_patterns/02-organisms/asset-viewer/asset-viewer-inline.yaml
@@ -1,92 +1,91 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    id:
-      type: string
-      minLength: 1
-    variant:
-      type: string
-      enum:
-        - figure
-        - table
-        - video
-        - supplement
-    classes:
-      type: string
-      minLength: 1
-    isSupplement:
-      type: boolean
-    supplementOrdinal:
-      type: integer
-      minimum: 1
-    parentId:
-      type: string
-      minLength: 1
-    label:
-      type: string
-      minLength: 1
-    supplementCount:
-      type: integer
-      minimum: 1
-    hasMultipleSupplements:
-      type: boolean
-    seeAllLink:
-      type: string
-      minLength: 1
-    captionedAsset:
-      allOf:
-        - $ref: ../../01-molecules/components/captioned-asset.yaml#/schema
-        - properties:
-            inline:
-              enum:
-                - false
-    additionalAssets:
-      type: array
-      minItems: 1
-      items:
-        $ref: ../../02-organisms/components/additional-assets.yaml#/schema
-    download:
-      type: object
-      properties:
-        link:
-          type: string
-          minLength: 1
-        filename:
-          type: string
-          minLength: 1
-      required:
-        - link
-        - filename
-    open:
-      type: object
-      properties:
-        uri:
-          type: string
-          minLength: 1
-        width:
-          type: integer
-          minimum: 1
-        height:
-          type: integer
-          minimum: 1
-      required:
-        - uri
-        - width
-        - height
-  dependencies:
-    parentId:
-      - supplementOrdinal
-    supplementOrdinal:
-      - parentId
-    supplementCount:
-      - hasMultipleSupplements
-    hasMultipleSupplements:
-      - supplementCount
-    seeAllLink:
-      - supplementCount
-  required:
-    - id
-    - variant
-    - label
-    - captionedAsset
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  id:
+    type: string
+    minLength: 1
+  variant:
+    type: string
+    enum:
+      - figure
+      - table
+      - video
+      - supplement
+  classes:
+    type: string
+    minLength: 1
+  isSupplement:
+    type: boolean
+  supplementOrdinal:
+    type: integer
+    minimum: 1
+  parentId:
+    type: string
+    minLength: 1
+  label:
+    type: string
+    minLength: 1
+  supplementCount:
+    type: integer
+    minimum: 1
+  hasMultipleSupplements:
+    type: boolean
+  seeAllLink:
+    type: string
+    minLength: 1
+  captionedAsset:
+    allOf:
+      - $ref: ../../01-molecules/components/captioned-asset.yaml#/schema
+      - properties:
+          inline:
+            enum:
+              - false
+  additionalAssets:
+    type: array
+    minItems: 1
+    items:
+      $ref: ../../02-organisms/components/additional-assets.yaml#/schema
+  download:
+    type: object
+    properties:
+      link:
+        type: string
+        minLength: 1
+      filename:
+        type: string
+        minLength: 1
+    required:
+      - link
+      - filename
+  open:
+    type: object
+    properties:
+      uri:
+        type: string
+        minLength: 1
+      width:
+        type: integer
+        minimum: 1
+      height:
+        type: integer
+        minimum: 1
+    required:
+      - uri
+      - width
+      - height
+dependencies:
+  parentId:
+    - supplementOrdinal
+  supplementOrdinal:
+    - parentId
+  supplementCount:
+    - hasMultipleSupplements
+  hasMultipleSupplements:
+    - supplementCount
+  seeAllLink:
+    - supplementCount
+required:
+  - id
+  - variant
+  - label
+  - captionedAsset

--- a/source/_patterns/02-organisms/asset-viewer/asset-viewer-inline.yaml
+++ b/source/_patterns/02-organisms/asset-viewer/asset-viewer-inline.yaml
@@ -35,7 +35,7 @@ properties:
     minLength: 1
   captionedAsset:
     allOf:
-      - $ref: ../../01-molecules/components/captioned-asset.yaml#/schema
+      - $ref: ../../01-molecules/components/captioned-asset.yaml
       - properties:
           inline:
             enum:
@@ -44,7 +44,7 @@ properties:
     type: array
     minItems: 1
     items:
-      $ref: ../../02-organisms/components/additional-assets.yaml#/schema
+      $ref: ../../02-organisms/components/additional-assets.yaml
   download:
     type: object
     properties:

--- a/source/_patterns/02-organisms/asset-viewer/asset-viewer-inline.yaml
+++ b/source/_patterns/02-organisms/asset-viewer/asset-viewer-inline.yaml
@@ -1,9 +1,3 @@
-assets:
-  css:
-    - asset-viewer-inline.css
-    - $ref: ../../01-molecules/components/captioned-asset.yaml#/assets/css
-    - $ref: ../../02-organisms/components/additional-assets.yaml#/assets/css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/02-organisms/components/about-profiles.yaml
+++ b/source/_patterns/02-organisms/components/about-profiles.yaml
@@ -1,9 +1,3 @@
-assets:
-  css:
-    - about-profiles.css
-    - $ref: ../../00-atoms/components/list-heading.yaml#/assets/css
-    - $ref: ../../01-molecules/components/about-profile.yaml#/assets/css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/02-organisms/components/about-profiles.yaml
+++ b/source/_patterns/02-organisms/components/about-profiles.yaml
@@ -1,16 +1,15 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    heading:
-      $ref: ../../00-atoms/components/list-heading.yaml#/schema
-    compact:
-      type: boolean
-      default: false
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  heading:
+    $ref: ../../00-atoms/components/list-heading.yaml#/schema
+  compact:
+    type: boolean
+    default: false
+  items:
+    type: array
+    minItems: 1
     items:
-      type: array
-      minItems: 1
-      items:
-        $ref: ../../01-molecules/components/about-profile.yaml#/schema
-  required:
-    - items
+      $ref: ../../01-molecules/components/about-profile.yaml#/schema
+required:
+  - items

--- a/source/_patterns/02-organisms/components/about-profiles.yaml
+++ b/source/_patterns/02-organisms/components/about-profiles.yaml
@@ -2,7 +2,7 @@ $schema: http://json-schema.org/draft-04/schema#
 type: object
 properties:
   heading:
-    $ref: ../../00-atoms/components/list-heading.yaml#/schema
+    $ref: ../../00-atoms/components/list-heading.yaml
   compact:
     type: boolean
     default: false
@@ -10,6 +10,6 @@ properties:
     type: array
     minItems: 1
     items:
-      $ref: ../../01-molecules/components/about-profile.yaml#/schema
+      $ref: ../../01-molecules/components/about-profile.yaml
 required:
   - items

--- a/source/_patterns/02-organisms/components/additional-assets.yaml
+++ b/source/_patterns/02-organisms/components/additional-assets.yaml
@@ -1,14 +1,13 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    heading:
-      type: string
-      minLength: 1
-    assets:
-      type: array
-      minItems: 1
-      items:
-        $ref: ../../01-molecules/components/additional-asset.yaml#/schema
-  required:
-    - assets
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  heading:
+    type: string
+    minLength: 1
+  assets:
+    type: array
+    minItems: 1
+    items:
+      $ref: ../../01-molecules/components/additional-asset.yaml#/schema
+required:
+  - assets

--- a/source/_patterns/02-organisms/components/additional-assets.yaml
+++ b/source/_patterns/02-organisms/components/additional-assets.yaml
@@ -8,6 +8,6 @@ properties:
     type: array
     minItems: 1
     items:
-      $ref: ../../01-molecules/components/additional-asset.yaml#/schema
+      $ref: ../../01-molecules/components/additional-asset.yaml
 required:
   - assets

--- a/source/_patterns/02-organisms/components/additional-assets.yaml
+++ b/source/_patterns/02-organisms/components/additional-assets.yaml
@@ -1,7 +1,3 @@
-assets:
-  css:
-    - $ref: ../../01-molecules/components/additional-asset.yaml#/assets/css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/02-organisms/components/box.yaml
+++ b/source/_patterns/02-organisms/components/box.yaml
@@ -15,7 +15,7 @@ properties:
     minimum: 1
     maximum: 6
   doi:
-    $ref: ../../00-atoms/components/doi.yaml#/schema
+    $ref: ../../00-atoms/components/doi.yaml
   content:
     type: string
     minLength: 1

--- a/source/_patterns/02-organisms/components/box.yaml
+++ b/source/_patterns/02-organisms/components/box.yaml
@@ -1,8 +1,3 @@
-assets:
-  css:
-    - box.css
-    - $ref: ../../00-atoms/components/doi.yaml#/assets/css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/02-organisms/components/box.yaml
+++ b/source/_patterns/02-organisms/components/box.yaml
@@ -1,26 +1,25 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    id:
-      type: string
-      minLength: 1
-    label:
-      type: string
-      minLength: 1
-    title:
-      type: string
-      minLength: 1
-    headingLevel:
-      type: integer
-      minimum: 1
-      maximum: 6
-    doi:
-      $ref: ../../00-atoms/components/doi.yaml#/schema
-    content:
-      type: string
-      minLength: 1
-  required:
-    - title
-    - headingLevel
-    - content
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  id:
+    type: string
+    minLength: 1
+  label:
+    type: string
+    minLength: 1
+  title:
+    type: string
+    minLength: 1
+  headingLevel:
+    type: integer
+    minimum: 1
+    maximum: 6
+  doi:
+    $ref: ../../00-atoms/components/doi.yaml#/schema
+  content:
+    type: string
+    minLength: 1
+required:
+  - title
+  - headingLevel
+  - content

--- a/source/_patterns/02-organisms/components/carousel.yaml
+++ b/source/_patterns/02-organisms/components/carousel.yaml
@@ -1,9 +1,3 @@
-assets:
-  css:
-    - carousel.css
-    - $ref: ../../00-atoms/components/list-heading.yaml#/assets/css
-    - $ref: ../../01-molecules/components/carousel-item.yaml#/assets/css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/02-organisms/components/carousel.yaml
+++ b/source/_patterns/02-organisms/components/carousel.yaml
@@ -2,11 +2,11 @@ $schema: http://json-schema.org/draft-04/schema#
 type: object
 properties:
   heading:
-    $ref: ../../00-atoms/components/list-heading.yaml#/schema
+    $ref: ../../00-atoms/components/list-heading.yaml
   items:
     type: array
     items:
-      - $ref: ../../01-molecules/components/carousel-item.yaml#/schema
+      - $ref: ../../01-molecules/components/carousel-item.yaml
     minItems: 1
 required:
   - heading

--- a/source/_patterns/02-organisms/components/carousel.yaml
+++ b/source/_patterns/02-organisms/components/carousel.yaml
@@ -1,14 +1,13 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    heading:
-      $ref: ../../00-atoms/components/list-heading.yaml#/schema
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  heading:
+    $ref: ../../00-atoms/components/list-heading.yaml#/schema
+  items:
+    type: array
     items:
-      type: array
-      items:
-        - $ref: ../../01-molecules/components/carousel-item.yaml#/schema
-      minItems: 1
-  required:
-    - heading
-    - items
+      - $ref: ../../01-molecules/components/carousel-item.yaml#/schema
+    minItems: 1
+required:
+  - heading
+  - items

--- a/source/_patterns/02-organisms/components/decision-letter-header.yaml
+++ b/source/_patterns/02-organisms/components/decision-letter-header.yaml
@@ -1,21 +1,20 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    mainText:
-      type: string
-      minLength: 1
-    hasProfiles:
-      type: boolean
-      enum:
-        - true
-    profiles:
-      type: array
-      minItems: 1
-      items:
-        $ref: ../../01-molecules/components/profile-snippet.yaml#/schema
-  required:
-    - mainText
-  dependencies:
-    hasProfiles: [profiles]
-    profiles: [hasProfiles]
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  mainText:
+    type: string
+    minLength: 1
+  hasProfiles:
+    type: boolean
+    enum:
+      - true
+  profiles:
+    type: array
+    minItems: 1
+    items:
+      $ref: ../../01-molecules/components/profile-snippet.yaml#/schema
+required:
+  - mainText
+dependencies:
+  hasProfiles: [profiles]
+  profiles: [hasProfiles]

--- a/source/_patterns/02-organisms/components/decision-letter-header.yaml
+++ b/source/_patterns/02-organisms/components/decision-letter-header.yaml
@@ -1,9 +1,3 @@
-assets:
-  css:
-    - decision-letter-header.css
-    - listing.css
-    - $ref: ../../01-molecules/components/profile-snippet.yaml#/assets/css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/02-organisms/components/decision-letter-header.yaml
+++ b/source/_patterns/02-organisms/components/decision-letter-header.yaml
@@ -12,7 +12,7 @@ properties:
     type: array
     minItems: 1
     items:
-      $ref: ../../01-molecules/components/profile-snippet.yaml#/schema
+      $ref: ../../01-molecules/components/profile-snippet.yaml
 required:
   - mainText
 dependencies:

--- a/source/_patterns/02-organisms/components/filter-panel.yaml
+++ b/source/_patterns/02-organisms/components/filter-panel.yaml
@@ -1,18 +1,17 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    title:
-      type: string
-      minLength: 1
-    filterGroups:
-      type: array
-      minItems: 1
-      items:
-        $ref: ../../01-molecules/components/filter-group.yaml#/schema
-    button:
-      $ref: ../../00-atoms/components/button.yaml#/schema
-  required:
-    - title
-    - filterGroups
-    - button
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  title:
+    type: string
+    minLength: 1
+  filterGroups:
+    type: array
+    minItems: 1
+    items:
+      $ref: ../../01-molecules/components/filter-group.yaml#/schema
+  button:
+    $ref: ../../00-atoms/components/button.yaml#/schema
+required:
+  - title
+  - filterGroups
+  - button

--- a/source/_patterns/02-organisms/components/filter-panel.yaml
+++ b/source/_patterns/02-organisms/components/filter-panel.yaml
@@ -1,8 +1,3 @@
-assets:
-  css:
-    - filter-panel.css
-    - $ref: ../../01-molecules/components/filter-group.yaml#/assets/css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/02-organisms/components/filter-panel.yaml
+++ b/source/_patterns/02-organisms/components/filter-panel.yaml
@@ -8,9 +8,9 @@ properties:
     type: array
     minItems: 1
     items:
-      $ref: ../../01-molecules/components/filter-group.yaml#/schema
+      $ref: ../../01-molecules/components/filter-group.yaml
   button:
-    $ref: ../../00-atoms/components/button.yaml#/schema
+    $ref: ../../00-atoms/components/button.yaml
 required:
   - title
   - filterGroups

--- a/source/_patterns/02-organisms/components/grid-listing.yaml
+++ b/source/_patterns/02-organisms/components/grid-listing.yaml
@@ -1,54 +1,53 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  allOf:
-    -
-      properties:
-        classes:
-          type: string
-          minLength: 1
-        heading:
-          $ref: ../../00-atoms/components/list-heading.yaml#/schema
-        id:
-          type: string
-          minLength: 1
-    -
-      oneOf:
-        -
-          properties:
-            blockLinks:
-              type: array
-              minItems: 1
-              items:
-                $ref: ../../00-atoms/components/block-link.yaml#/schema
-          required:
-            - blockLinks
-        -
-          properties:
-            archiveNavLinks:
-              type: array
-              minItems: 1
-              items:
-                $ref: ../../01-molecules/components/archive-nav-link.yaml#/schema
-          required:
-            - archiveNavLinks
-        -
-          properties:
-            imageLinks:
-              type: array
-              minItems: 1
-              items:
-                $ref: ../../00-atoms/components/image-link.yaml#/schema
-          required:
-            - imageLinks
-        -
-          properties:
-            teasers:
-              type: array
-              minItems: 1
-              items:
-                $ref: ../../01-molecules/teasers/teaser.yaml#/schema
-            pagination:
-              $ref: ../../01-molecules/navigation/pager.yaml#/schema
-          required:
-            - teasers
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+allOf:
+  -
+    properties:
+      classes:
+        type: string
+        minLength: 1
+      heading:
+        $ref: ../../00-atoms/components/list-heading.yaml#/schema
+      id:
+        type: string
+        minLength: 1
+  -
+    oneOf:
+      -
+        properties:
+          blockLinks:
+            type: array
+            minItems: 1
+            items:
+              $ref: ../../00-atoms/components/block-link.yaml#/schema
+        required:
+          - blockLinks
+      -
+        properties:
+          archiveNavLinks:
+            type: array
+            minItems: 1
+            items:
+              $ref: ../../01-molecules/components/archive-nav-link.yaml#/schema
+        required:
+          - archiveNavLinks
+      -
+        properties:
+          imageLinks:
+            type: array
+            minItems: 1
+            items:
+              $ref: ../../00-atoms/components/image-link.yaml#/schema
+        required:
+          - imageLinks
+      -
+        properties:
+          teasers:
+            type: array
+            minItems: 1
+            items:
+              $ref: ../../01-molecules/teasers/teaser.yaml#/schema
+          pagination:
+            $ref: ../../01-molecules/navigation/pager.yaml#/schema
+        required:
+          - teasers

--- a/source/_patterns/02-organisms/components/grid-listing.yaml
+++ b/source/_patterns/02-organisms/components/grid-listing.yaml
@@ -1,13 +1,3 @@
-assets:
-  css:
-    - grid-listing.css
-    - $ref: ../../00-atoms/components/block-link.yaml#/assets/css
-    - $ref: ../../00-atoms/components/image-link.yaml#/assets/css
-    - $ref: ../../00-atoms/components/list-heading.yaml#/assets/css
-    - $ref: ../../01-molecules/components/archive-nav-link.yaml#/assets/css
-    - $ref: ../../01-molecules/navigation/pager.yaml#/assets/css
-    - $ref: ../../01-molecules/teasers/teaser.yaml#/assets/css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/02-organisms/components/grid-listing.yaml
+++ b/source/_patterns/02-organisms/components/grid-listing.yaml
@@ -7,7 +7,7 @@ allOf:
         type: string
         minLength: 1
       heading:
-        $ref: ../../00-atoms/components/list-heading.yaml#/schema
+        $ref: ../../00-atoms/components/list-heading.yaml
       id:
         type: string
         minLength: 1
@@ -19,7 +19,7 @@ allOf:
             type: array
             minItems: 1
             items:
-              $ref: ../../00-atoms/components/block-link.yaml#/schema
+              $ref: ../../00-atoms/components/block-link.yaml
         required:
           - blockLinks
       -
@@ -28,7 +28,7 @@ allOf:
             type: array
             minItems: 1
             items:
-              $ref: ../../01-molecules/components/archive-nav-link.yaml#/schema
+              $ref: ../../01-molecules/components/archive-nav-link.yaml
         required:
           - archiveNavLinks
       -
@@ -37,7 +37,7 @@ allOf:
             type: array
             minItems: 1
             items:
-              $ref: ../../00-atoms/components/image-link.yaml#/schema
+              $ref: ../../00-atoms/components/image-link.yaml
         required:
           - imageLinks
       -
@@ -46,8 +46,8 @@ allOf:
             type: array
             minItems: 1
             items:
-              $ref: ../../01-molecules/teasers/teaser.yaml#/schema
+              $ref: ../../01-molecules/teasers/teaser.yaml
           pagination:
-            $ref: ../../01-molecules/navigation/pager.yaml#/schema
+            $ref: ../../01-molecules/navigation/pager.yaml
         required:
           - teasers

--- a/source/_patterns/02-organisms/components/listing-annotation-teasers.yaml
+++ b/source/_patterns/02-organisms/components/listing-annotation-teasers.yaml
@@ -1,18 +1,17 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    heading:
-      $ref: ../../00-atoms/components/list-heading.yaml#/schema
-    id:
-      type: string
-      pattern: ^[a-zA-Z0-9_$]+$
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  heading:
+    $ref: ../../00-atoms/components/list-heading.yaml#/schema
+  id:
+    type: string
+    pattern: ^[a-zA-Z0-9_$]+$
+  items:
+    type: array
+    minItems: 1
     items:
-      type: array
-      minItems: 1
-      items:
-        $ref: ../../01-molecules/teasers/annotation-teaser.yaml#/schema
-    pagination:
-      $ref: ../../01-molecules/navigation/pager.yaml#/schema
-  required:
-    - items
+      $ref: ../../01-molecules/teasers/annotation-teaser.yaml#/schema
+  pagination:
+    $ref: ../../01-molecules/navigation/pager.yaml#/schema
+required:
+  - items

--- a/source/_patterns/02-organisms/components/listing-annotation-teasers.yaml
+++ b/source/_patterns/02-organisms/components/listing-annotation-teasers.yaml
@@ -2,7 +2,7 @@ $schema: http://json-schema.org/draft-04/schema#
 type: object
 properties:
   heading:
-    $ref: ../../00-atoms/components/list-heading.yaml#/schema
+    $ref: ../../00-atoms/components/list-heading.yaml
   id:
     type: string
     pattern: ^[a-zA-Z0-9_$]+$
@@ -10,8 +10,8 @@ properties:
     type: array
     minItems: 1
     items:
-      $ref: ../../01-molecules/teasers/annotation-teaser.yaml#/schema
+      $ref: ../../01-molecules/teasers/annotation-teaser.yaml
   pagination:
-    $ref: ../../01-molecules/navigation/pager.yaml#/schema
+    $ref: ../../01-molecules/navigation/pager.yaml
 required:
   - items

--- a/source/_patterns/02-organisms/components/listing-annotation-teasers.yaml
+++ b/source/_patterns/02-organisms/components/listing-annotation-teasers.yaml
@@ -1,10 +1,3 @@
-assets:
-  css:
-    - listing.css
-    - $ref: ../../00-atoms/components/list-heading.yaml#/assets/css
-    - $ref: ../../01-molecules/teasers/annotation-teaser.yaml#/assets/css
-    - $ref: ../../01-molecules/navigation/pager.yaml#/assets/css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/02-organisms/components/listing-profile-snippets.yaml
+++ b/source/_patterns/02-organisms/components/listing-profile-snippets.yaml
@@ -1,10 +1,3 @@
-assets:
-  css:
-    - listing.css
-    - $ref: ../../00-atoms/components/list-heading.yaml#/assets/css
-    - $ref: ../../01-molecules/components/profile-snippet.yaml#/assets/css
-    - $ref: ../../00-atoms/components/see-more-link.yaml#/assets/css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/02-organisms/components/listing-profile-snippets.yaml
+++ b/source/_patterns/02-organisms/components/listing-profile-snippets.yaml
@@ -2,13 +2,13 @@ $schema: http://json-schema.org/draft-04/schema#
 type: object
 properties:
   heading:
-    $ref: ../../00-atoms/components/list-heading.yaml#/schema
+    $ref: ../../00-atoms/components/list-heading.yaml
   items:
     type: array
     minItems: 1
     items:
-      $ref: ../../01-molecules/components/profile-snippet.yaml#/schema
+      $ref: ../../01-molecules/components/profile-snippet.yaml
   seeMoreLink:
-    $ref: ../../00-atoms/components/see-more-link.yaml#/schema
+    $ref: ../../00-atoms/components/see-more-link.yaml
 required:
   - items

--- a/source/_patterns/02-organisms/components/listing-profile-snippets.yaml
+++ b/source/_patterns/02-organisms/components/listing-profile-snippets.yaml
@@ -1,15 +1,14 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    heading:
-      $ref: ../../00-atoms/components/list-heading.yaml#/schema
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  heading:
+    $ref: ../../00-atoms/components/list-heading.yaml#/schema
+  items:
+    type: array
+    minItems: 1
     items:
-      type: array
-      minItems: 1
-      items:
-        $ref: ../../01-molecules/components/profile-snippet.yaml#/schema
-    seeMoreLink:
-      $ref: ../../00-atoms/components/see-more-link.yaml#/schema
-  required:
-    - items
+      $ref: ../../01-molecules/components/profile-snippet.yaml#/schema
+  seeMoreLink:
+    $ref: ../../00-atoms/components/see-more-link.yaml#/schema
+required:
+  - items

--- a/source/_patterns/02-organisms/components/listing-read-more.yaml
+++ b/source/_patterns/02-organisms/components/listing-read-more.yaml
@@ -1,11 +1,3 @@
-assets:
-  css:
-    - listing.css
-    - $ref: ../../00-atoms/components/list-heading.yaml#/assets/css
-    - $ref: ../../02-organisms/components/read-more-item.yaml#/assets/css
-    - $ref: ../../01-molecules/navigation/pager.yaml#/assets/css
-    - $ref: ../../00-atoms/components/see-more-link.yaml#/assets/css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/02-organisms/components/listing-read-more.yaml
+++ b/source/_patterns/02-organisms/components/listing-read-more.yaml
@@ -4,7 +4,7 @@ properties:
   allRelated:
     type: boolean
   heading:
-    $ref: ../../00-atoms/components/list-heading.yaml#/schema
+    $ref: ../../00-atoms/components/list-heading.yaml
   id:
     type: string
     pattern: ^[a-zA-Z0-9_$]+$
@@ -12,10 +12,10 @@ properties:
     type: array
     minItems: 1
     items:
-      $ref: ../../02-organisms/components/read-more-item.yaml#/schema
+      $ref: ../../02-organisms/components/read-more-item.yaml
   pagination:
-    $ref: ../../01-molecules/navigation/pager.yaml#/schema
+    $ref: ../../01-molecules/navigation/pager.yaml
   seeMoreLink:
-    $ref: ../../00-atoms/components/see-more-link.yaml#/schema
+    $ref: ../../00-atoms/components/see-more-link.yaml
 required:
   - items

--- a/source/_patterns/02-organisms/components/listing-read-more.yaml
+++ b/source/_patterns/02-organisms/components/listing-read-more.yaml
@@ -1,22 +1,21 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    allRelated:
-      type: boolean
-    heading:
-      $ref: ../../00-atoms/components/list-heading.yaml#/schema
-    id:
-      type: string
-      pattern: ^[a-zA-Z0-9_$]+$
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  allRelated:
+    type: boolean
+  heading:
+    $ref: ../../00-atoms/components/list-heading.yaml#/schema
+  id:
+    type: string
+    pattern: ^[a-zA-Z0-9_$]+$
+  items:
+    type: array
+    minItems: 1
     items:
-      type: array
-      minItems: 1
-      items:
-        $ref: ../../02-organisms/components/read-more-item.yaml#/schema
-    pagination:
-      $ref: ../../01-molecules/navigation/pager.yaml#/schema
-    seeMoreLink:
-      $ref: ../../00-atoms/components/see-more-link.yaml#/schema
-  required:
-    - items
+      $ref: ../../02-organisms/components/read-more-item.yaml#/schema
+  pagination:
+    $ref: ../../01-molecules/navigation/pager.yaml#/schema
+  seeMoreLink:
+    $ref: ../../00-atoms/components/see-more-link.yaml#/schema
+required:
+  - items

--- a/source/_patterns/02-organisms/components/listing-teasers.yaml
+++ b/source/_patterns/02-organisms/components/listing-teasers.yaml
@@ -1,23 +1,22 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    heading:
-      $ref: ../../00-atoms/components/list-heading.yaml#/schema
-    id:
-      type: string
-      pattern: ^[a-zA-Z0-9_$]+$
-    highlights:
-      type: boolean
-      default: false
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  heading:
+    $ref: ../../00-atoms/components/list-heading.yaml#/schema
+  id:
+    type: string
+    pattern: ^[a-zA-Z0-9_$]+$
+  highlights:
+    type: boolean
+    default: false
+  items:
+    type: array
+    minItems: 1
     items:
-      type: array
-      minItems: 1
-      items:
-        $ref: ../../01-molecules/teasers/teaser.yaml#/schema
-    pagination:
-      $ref: ../../01-molecules/navigation/pager.yaml#/schema
-    seeMoreLink:
-      $ref: ../../00-atoms/components/see-more-link.yaml#/schema
-  required:
-    - items
+      $ref: ../../01-molecules/teasers/teaser.yaml#/schema
+  pagination:
+    $ref: ../../01-molecules/navigation/pager.yaml#/schema
+  seeMoreLink:
+    $ref: ../../00-atoms/components/see-more-link.yaml#/schema
+required:
+  - items

--- a/source/_patterns/02-organisms/components/listing-teasers.yaml
+++ b/source/_patterns/02-organisms/components/listing-teasers.yaml
@@ -2,7 +2,7 @@ $schema: http://json-schema.org/draft-04/schema#
 type: object
 properties:
   heading:
-    $ref: ../../00-atoms/components/list-heading.yaml#/schema
+    $ref: ../../00-atoms/components/list-heading.yaml
   id:
     type: string
     pattern: ^[a-zA-Z0-9_$]+$
@@ -13,10 +13,10 @@ properties:
     type: array
     minItems: 1
     items:
-      $ref: ../../01-molecules/teasers/teaser.yaml#/schema
+      $ref: ../../01-molecules/teasers/teaser.yaml
   pagination:
-    $ref: ../../01-molecules/navigation/pager.yaml#/schema
+    $ref: ../../01-molecules/navigation/pager.yaml
   seeMoreLink:
-    $ref: ../../00-atoms/components/see-more-link.yaml#/schema
+    $ref: ../../00-atoms/components/see-more-link.yaml
 required:
   - items

--- a/source/_patterns/02-organisms/components/listing-teasers.yaml
+++ b/source/_patterns/02-organisms/components/listing-teasers.yaml
@@ -1,11 +1,3 @@
-assets:
-  css:
-    - listing.css
-    - $ref: ../../00-atoms/components/list-heading.yaml#/assets/css
-    - $ref: ../../01-molecules/teasers/teaser.yaml#/assets/css
-    - $ref: ../../01-molecules/navigation/pager.yaml#/assets/css
-    - $ref: ../../00-atoms/components/see-more-link.yaml#/assets/css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/02-organisms/components/read-more-item.yaml
+++ b/source/_patterns/02-organisms/components/read-more-item.yaml
@@ -2,7 +2,7 @@ $schema: http://json-schema.org/draft-04/schema#
 type: object
 properties:
   item:
-    $ref: ../../02-organisms/content-headers/content-header-read-more.yaml#/schema
+    $ref: ../../02-organisms/content-headers/content-header-read-more.yaml
   content:
     type: string
   isRelated:

--- a/source/_patterns/02-organisms/components/read-more-item.yaml
+++ b/source/_patterns/02-organisms/components/read-more-item.yaml
@@ -1,8 +1,3 @@
-assets:
-  css:
-    - listing.css
-    - $ref: ../../02-organisms/content-headers/content-header-read-more.yaml#/assets/css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/02-organisms/components/read-more-item.yaml
+++ b/source/_patterns/02-organisms/components/read-more-item.yaml
@@ -1,14 +1,13 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    item:
-      $ref: ../../02-organisms/content-headers/content-header-read-more.yaml#/schema
-    content:
-      type: string
-    isRelated:
-      type: boolean
-      emum:
-        - true
-  required:
-    - item
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  item:
+    $ref: ../../02-organisms/content-headers/content-header-read-more.yaml#/schema
+  content:
+    type: string
+  isRelated:
+    type: boolean
+    emum:
+      - true
+required:
+  - item

--- a/source/_patterns/02-organisms/components/statistic-collection.yaml
+++ b/source/_patterns/02-organisms/components/statistic-collection.yaml
@@ -1,8 +1,3 @@
-assets:
-  css:
-    - $ref: ../../01-molecules/components/statistic.yaml#/assets/css
-    - statistic-collection.css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/02-organisms/components/statistic-collection.yaml
+++ b/source/_patterns/02-organisms/components/statistic-collection.yaml
@@ -1,11 +1,10 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    stats:
-      type: array
-      minItems: 1
-      items:
-        $ref: ../../01-molecules/components/statistic.yaml#/schema
-  required:
-    - stats
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  stats:
+    type: array
+    minItems: 1
+    items:
+      $ref: ../../01-molecules/components/statistic.yaml#/schema
+required:
+  - stats

--- a/source/_patterns/02-organisms/components/statistic-collection.yaml
+++ b/source/_patterns/02-organisms/components/statistic-collection.yaml
@@ -5,6 +5,6 @@ properties:
     type: array
     minItems: 1
     items:
-      $ref: ../../01-molecules/components/statistic.yaml#/schema
+      $ref: ../../01-molecules/components/statistic.yaml
 required:
   - stats

--- a/source/_patterns/02-organisms/content-headers/content-header-profile.yaml
+++ b/source/_patterns/02-organisms/content-headers/content-header-profile.yaml
@@ -17,13 +17,13 @@ properties:
         type: string
         format: email
       orcid:
-        $ref: ../../00-atoms/components/orcid.yaml#/schema
+        $ref: ../../00-atoms/components/orcid.yaml
     minProperties: 1
   secondaryLinks:
     type: array
     items:
-      $ref: ../../../non-pattern-schema/link.yaml#/schema
+      $ref: ../../../non-pattern-schema/link.yaml
   logoutLink:
-    $ref: ../../../non-pattern-schema/link.yaml#/schema
+    $ref: ../../../non-pattern-schema/link.yaml
 required:
   - displayName

--- a/source/_patterns/02-organisms/content-headers/content-header-profile.yaml
+++ b/source/_patterns/02-organisms/content-headers/content-header-profile.yaml
@@ -1,30 +1,29 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    displayName:
-      type: string
-      minLength: 1
-    details:
-      type: object
-      properties:
-        affiliations:
-          type: array
-          items:
-            type: string
-            minLength: 1
-          minItems: 1
-        emailAddress:
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  displayName:
+    type: string
+    minLength: 1
+  details:
+    type: object
+    properties:
+      affiliations:
+        type: array
+        items:
           type: string
-          format: email
-        orcid:
-          $ref: ../../00-atoms/components/orcid.yaml#/schema
-      minProperties: 1
-    secondaryLinks:
-      type: array
-      items:
-        $ref: ../../../non-pattern-schema/link.yaml#/schema
-    logoutLink:
+          minLength: 1
+        minItems: 1
+      emailAddress:
+        type: string
+        format: email
+      orcid:
+        $ref: ../../00-atoms/components/orcid.yaml#/schema
+    minProperties: 1
+  secondaryLinks:
+    type: array
+    items:
       $ref: ../../../non-pattern-schema/link.yaml#/schema
-  required:
-    - displayName
+  logoutLink:
+    $ref: ../../../non-pattern-schema/link.yaml#/schema
+required:
+  - displayName

--- a/source/_patterns/02-organisms/content-headers/content-header-profile.yaml
+++ b/source/_patterns/02-organisms/content-headers/content-header-profile.yaml
@@ -1,8 +1,3 @@
-assets:
-  css:
-    - content-header-profile.css
-    - $ref: ../../00-atoms/components/orcid.yaml#/assets/css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/02-organisms/content-headers/content-header-read-more.yaml
+++ b/source/_patterns/02-organisms/content-headers/content-header-read-more.yaml
@@ -1,38 +1,37 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    title:
-      type: string
-      minLength: 1
-    longTitle:
-      type: boolean
-    url:
-      type: string
-      minLength: 1
-    hasSubjects:
-      type: boolean
-      enum:
-        - true
-    subjects:
-      type: array
-      minItems: 1
-      items:
-        type: object
-        properties:
-          name:
-            type: string
-            minLength: 1
-        required:
-          - name
-    authorLine:
-      type: string
-      minLength: 1
-    meta:
-      $ref: ../../01-molecules/components/meta.yaml#/schema
-  required:
-    - title
-    - url
-  dependencies:
-    hasSubjects: [subjects]
-    subjects: [hasSubjects]
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  title:
+    type: string
+    minLength: 1
+  longTitle:
+    type: boolean
+  url:
+    type: string
+    minLength: 1
+  hasSubjects:
+    type: boolean
+    enum:
+      - true
+  subjects:
+    type: array
+    minItems: 1
+    items:
+      type: object
+      properties:
+        name:
+          type: string
+          minLength: 1
+      required:
+        - name
+  authorLine:
+    type: string
+    minLength: 1
+  meta:
+    $ref: ../../01-molecules/components/meta.yaml#/schema
+required:
+  - title
+  - url
+dependencies:
+  hasSubjects: [subjects]
+  subjects: [hasSubjects]

--- a/source/_patterns/02-organisms/content-headers/content-header-read-more.yaml
+++ b/source/_patterns/02-organisms/content-headers/content-header-read-more.yaml
@@ -1,8 +1,3 @@
-assets:
-  css:
-    - content-header.css
-    - $ref: ../../01-molecules/components/meta.yaml#/assets/css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/02-organisms/content-headers/content-header-read-more.yaml
+++ b/source/_patterns/02-organisms/content-headers/content-header-read-more.yaml
@@ -28,7 +28,7 @@ properties:
     type: string
     minLength: 1
   meta:
-    $ref: ../../01-molecules/components/meta.yaml#/schema
+    $ref: ../../01-molecules/components/meta.yaml
 required:
   - title
   - url

--- a/source/_patterns/02-organisms/content-headers/content-header-simple.yaml
+++ b/source/_patterns/02-organisms/content-headers/content-header-simple.yaml
@@ -1,7 +1,3 @@
-assets:
-  css:
-    - content-header-simple.css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/02-organisms/content-headers/content-header-simple.yaml
+++ b/source/_patterns/02-organisms/content-headers/content-header-simple.yaml
@@ -1,12 +1,11 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    title:
-      type: string
-      minLength: 1
-    strapline:
-      type: string
-      minLength: 1
-  required:
-    - title
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  title:
+    type: string
+    minLength: 1
+  strapline:
+    type: string
+    minLength: 1
+required:
+  - title

--- a/source/_patterns/02-organisms/content-headers/content-header.yaml
+++ b/source/_patterns/02-organisms/content-headers/content-header.yaml
@@ -1,11 +1,3 @@
-assets:
-  css:
-    - content-header.css
-    - $ref: ../../00-atoms/components/social-media-sharers.yaml#/assets/css
-    - $ref: ../../01-molecules/components/meta.yaml#/assets/css
-    - $ref: ../../01-molecules/components/audio-player.yaml#/assets/css
-    - $ref: ../../01-molecules/navigation/select-nav.yaml#/assets/css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/02-organisms/content-headers/content-header.yaml
+++ b/source/_patterns/02-organisms/content-headers/content-header.yaml
@@ -1,65 +1,97 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    title:
-      type: string
-      minLength: 1
-    longTitle:
-      type: boolean
-    image:
-      allOf:
-        - $ref: ../../00-atoms/components/picture.yaml#/schema
-        - properties:
-            credit:
-              type: object
-              properties:
-                text:
-                  type: string
-                  minLength: 1
-                elementId:
-                  type: string
-                  minLength: 1
-              required:
-                - text
-                - elementId
-            creditOverlay:
-              type: boolean
-              default: false
-    impactStatement:
-      type: string
-      minLength: 1
-    header:
-      type: object
-      properties:
-        possible:
-          type: boolean
-          enum:
-            - true
-        hasSubjects:
-          type: boolean
-          enum:
-            - true
-        subjects:
-          type: array
-          minItems: 1
-          items:
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  title:
+    type: string
+    minLength: 1
+  longTitle:
+    type: boolean
+  image:
+    allOf:
+      - $ref: ../../00-atoms/components/picture.yaml#/schema
+      - properties:
+          credit:
             type: object
             properties:
-              name:
+              text:
                 type: string
                 minLength: 1
-              url:
+              elementId:
                 type: string
                 minLength: 1
             required:
-              - name
-              - url
-        hasProfile:
-          type: boolean
-          enum:
-            - true
-        profile:
+              - text
+              - elementId
+          creditOverlay:
+            type: boolean
+            default: false
+  impactStatement:
+    type: string
+    minLength: 1
+  header:
+    type: object
+    properties:
+      possible:
+        type: boolean
+        enum:
+          - true
+      hasSubjects:
+        type: boolean
+        enum:
+          - true
+      subjects:
+        type: array
+        minItems: 1
+        items:
+          type: object
+          properties:
+            name:
+              type: string
+              minLength: 1
+            url:
+              type: string
+              minLength: 1
+          required:
+            - name
+            - url
+      hasProfile:
+        type: boolean
+        enum:
+          - true
+      profile:
+        type: object
+        properties:
+          name:
+            type: string
+            minLength: 1
+          url:
+            oneOf:
+              - type: string
+                minLength: 1
+              - type: boolean
+                enum:
+                  - false
+          image:
+            $ref: ../../00-atoms/components/picture.yaml#/schema
+        required:
+          - name
+          - url
+    required:
+      - possible
+    dependencies:
+      hasSubjects: [subjects]
+      subjects: [hasSubjects]
+      hasProfile: [profile]
+      profile: [hasProfile]
+  socialMediaSharers:
+    $ref: ../../00-atoms/components/social-media-sharers.yaml#/schema
+  authors:
+    type: object
+    properties:
+      list:
+        type: array
+        minItems: 1
+        items:
           type: object
           properties:
             name:
@@ -72,72 +104,39 @@ schema:
                 - type: boolean
                   enum:
                     - false
-            image:
-              $ref: ../../00-atoms/components/picture.yaml#/schema
+            isCorresponding:
+              type: boolean
           required:
             - name
             - url
-      required:
-        - possible
-      dependencies:
-        hasSubjects: [subjects]
-        subjects: [hasSubjects]
-        hasProfile: [profile]
-        profile: [hasProfile]
-    socialMediaSharers:
-      $ref: ../../00-atoms/components/social-media-sharers.yaml#/schema
-    authors:
-      type: object
-      properties:
-        list:
-          type: array
-          minItems: 1
-          items:
-            type: object
-            properties:
-              name:
-                type: string
-                minLength: 1
-              url:
-                oneOf:
-                  - type: string
-                    minLength: 1
-                  - type: boolean
-                    enum:
-                      - false
-              isCorresponding:
-                type: boolean
-            required:
-              - name
-              - url
-      required:
-        - list
-    institutions:
-      type: object
-      properties:
-        list:
-          type: array
-          minItems: 1
-          items:
-            type: object
-            properties:
-              name:
-                type: string
-                minLength: 1
-            required:
-              - name
-      required:
-        - list
-    download:
-      type: string
-      minLength: 1
-    selectNav:
-      $ref: ../../01-molecules/navigation/select-nav.yaml#/schema
-    meta:
-      $ref: ../../01-molecules/components/meta.yaml#/schema
-    audioPlayer:
-      $ref: ../../01-molecules/components/audio-player.yaml#/schema
-  required:
-    - title
-  dependencies:
-    institutions: [authors]
+    required:
+      - list
+  institutions:
+    type: object
+    properties:
+      list:
+        type: array
+        minItems: 1
+        items:
+          type: object
+          properties:
+            name:
+              type: string
+              minLength: 1
+          required:
+            - name
+    required:
+      - list
+  download:
+    type: string
+    minLength: 1
+  selectNav:
+    $ref: ../../01-molecules/navigation/select-nav.yaml#/schema
+  meta:
+    $ref: ../../01-molecules/components/meta.yaml#/schema
+  audioPlayer:
+    $ref: ../../01-molecules/components/audio-player.yaml#/schema
+required:
+  - title
+dependencies:
+  institutions: [authors]

--- a/source/_patterns/02-organisms/content-headers/content-header.yaml
+++ b/source/_patterns/02-organisms/content-headers/content-header.yaml
@@ -8,7 +8,7 @@ properties:
     type: boolean
   image:
     allOf:
-      - $ref: ../../00-atoms/components/picture.yaml#/schema
+      - $ref: ../../00-atoms/components/picture.yaml
       - properties:
           credit:
             type: object
@@ -72,7 +72,7 @@ properties:
                 enum:
                   - false
           image:
-            $ref: ../../00-atoms/components/picture.yaml#/schema
+            $ref: ../../00-atoms/components/picture.yaml
         required:
           - name
           - url
@@ -84,7 +84,7 @@ properties:
       hasProfile: [profile]
       profile: [hasProfile]
   socialMediaSharers:
-    $ref: ../../00-atoms/components/social-media-sharers.yaml#/schema
+    $ref: ../../00-atoms/components/social-media-sharers.yaml
   authors:
     type: object
     properties:
@@ -131,11 +131,11 @@ properties:
     type: string
     minLength: 1
   selectNav:
-    $ref: ../../01-molecules/navigation/select-nav.yaml#/schema
+    $ref: ../../01-molecules/navigation/select-nav.yaml
   meta:
-    $ref: ../../01-molecules/components/meta.yaml#/schema
+    $ref: ../../01-molecules/components/meta.yaml
   audioPlayer:
-    $ref: ../../01-molecules/components/audio-player.yaml#/schema
+    $ref: ../../01-molecules/components/audio-player.yaml
 required:
   - title
 dependencies:

--- a/source/_patterns/02-organisms/global/email-cta.yaml
+++ b/source/_patterns/02-organisms/global/email-cta.yaml
@@ -1,9 +1,3 @@
-assets:
-  css:
-    - email-cta.css
-    - $ref: ../../00-atoms/forms/form-field-info-link.yaml#/assets/css
-    - $ref: ../../01-molecules/components/compact-form.yaml#/assets/css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/02-organisms/global/email-cta.yaml
+++ b/source/_patterns/02-organisms/global/email-cta.yaml
@@ -1,19 +1,18 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    emailCta:
-      headerText:
-        type: string
-        minLength: 1
-      subHeader:
-        type: string
-        minLength: 1
-      formFieldInfoLink:
-        $ref: ../../00-atoms/forms/form-field-info-link.yaml#/schema
-      compactForm:
-        $ref: ../../01-molecules/components/compact-form.yaml#/schema
-      required:
-        - headerText
-        - subHeader
-        - compactForm
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  emailCta:
+    headerText:
+      type: string
+      minLength: 1
+    subHeader:
+      type: string
+      minLength: 1
+    formFieldInfoLink:
+      $ref: ../../00-atoms/forms/form-field-info-link.yaml#/schema
+    compactForm:
+      $ref: ../../01-molecules/components/compact-form.yaml#/schema
+    required:
+      - headerText
+      - subHeader
+      - compactForm

--- a/source/_patterns/02-organisms/global/email-cta.yaml
+++ b/source/_patterns/02-organisms/global/email-cta.yaml
@@ -9,9 +9,9 @@ properties:
       type: string
       minLength: 1
     formFieldInfoLink:
-      $ref: ../../00-atoms/forms/form-field-info-link.yaml#/schema
+      $ref: ../../00-atoms/forms/form-field-info-link.yaml
     compactForm:
-      $ref: ../../01-molecules/components/compact-form.yaml#/schema
+      $ref: ../../01-molecules/components/compact-form.yaml
     required:
       - headerText
       - subHeader

--- a/source/_patterns/02-organisms/global/footer.yaml
+++ b/source/_patterns/02-organisms/global/footer.yaml
@@ -1,27 +1,26 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  allOf:
-    - properties:
-        year:
-          type: integer
-        footerMenuLinks:
-          type: array
-          items:
-            type: object
-            properties:
-              name:
-                type: string
-                minLength: 1
-              url:
-                type: string
-                minLength: 1
-            required:
-              - name
-              - url
-          minItems: 1
-      required:
-        - year
-        - footerMenuLinks
-    - $ref: ../../01-molecules/navigation/main-menu.yaml#/schema
-    - $ref: ../../01-molecules/components/investor-logos.yaml#/schema
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+allOf:
+  - properties:
+      year:
+        type: integer
+      footerMenuLinks:
+        type: array
+        items:
+          type: object
+          properties:
+            name:
+              type: string
+              minLength: 1
+            url:
+              type: string
+              minLength: 1
+          required:
+            - name
+            - url
+        minItems: 1
+    required:
+      - year
+      - footerMenuLinks
+  - $ref: ../../01-molecules/navigation/main-menu.yaml#/schema
+  - $ref: ../../01-molecules/components/investor-logos.yaml#/schema

--- a/source/_patterns/02-organisms/global/footer.yaml
+++ b/source/_patterns/02-organisms/global/footer.yaml
@@ -22,5 +22,5 @@ allOf:
     required:
       - year
       - footerMenuLinks
-  - $ref: ../../01-molecules/navigation/main-menu.yaml#/schema
-  - $ref: ../../01-molecules/components/investor-logos.yaml#/schema
+  - $ref: ../../01-molecules/navigation/main-menu.yaml
+  - $ref: ../../01-molecules/components/investor-logos.yaml

--- a/source/_patterns/02-organisms/global/footer.yaml
+++ b/source/_patterns/02-organisms/global/footer.yaml
@@ -1,11 +1,3 @@
-assets:
-  css:
-    - site-footer.css
-    - $ref: ../../01-molecules/navigation/main-menu.yaml#/assets/css
-    - $ref: ../../01-molecules/components/investor-logos.yaml#/assets/css
-  js:
-    - $ref: ../../01-molecules/navigation/main-menu.yaml#/assets/js
-    - $ref: ../../01-molecules/components/investor-logos.yaml#/assets/js
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/02-organisms/global/site-header.yaml
+++ b/source/_patterns/02-organisms/global/site-header.yaml
@@ -1,9 +1,3 @@
-assets:
-  css:
-    - site-header.css
-    - $ref: ../../01-molecules/navigation/site-header-nav-bar.yaml#/assets/css
-    - $ref: ../../01-molecules/components/search-box.yaml#/assets/css
-  js: []
 schema:
   $schema: http://json-schema.org/draft-04/schema#
   type: object

--- a/source/_patterns/02-organisms/global/site-header.yaml
+++ b/source/_patterns/02-organisms/global/site-header.yaml
@@ -1,17 +1,16 @@
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    homePagePath:
-      type: string
-      minLength: 1
-    primaryLinks:
-      $ref: ../../01-molecules/navigation/site-header-nav-bar.yaml#/schema
-    secondaryLinks:
-      $ref: ../../01-molecules/navigation/site-header-nav-bar.yaml#/schema
-    searchBox:
-      $ref: ../../01-molecules/components/search-box.yaml#/schema
-  required:
-    - homePagePath
-    - primaryLinks
-    - secondaryLinks
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  homePagePath:
+    type: string
+    minLength: 1
+  primaryLinks:
+    $ref: ../../01-molecules/navigation/site-header-nav-bar.yaml#/schema
+  secondaryLinks:
+    $ref: ../../01-molecules/navigation/site-header-nav-bar.yaml#/schema
+  searchBox:
+    $ref: ../../01-molecules/components/search-box.yaml#/schema
+required:
+  - homePagePath
+  - primaryLinks
+  - secondaryLinks

--- a/source/_patterns/02-organisms/global/site-header.yaml
+++ b/source/_patterns/02-organisms/global/site-header.yaml
@@ -5,11 +5,11 @@ properties:
     type: string
     minLength: 1
   primaryLinks:
-    $ref: ../../01-molecules/navigation/site-header-nav-bar.yaml#/schema
+    $ref: ../../01-molecules/navigation/site-header-nav-bar.yaml
   secondaryLinks:
-    $ref: ../../01-molecules/navigation/site-header-nav-bar.yaml#/schema
+    $ref: ../../01-molecules/navigation/site-header-nav-bar.yaml
   searchBox:
-    $ref: ../../01-molecules/components/search-box.yaml#/schema
+    $ref: ../../01-molecules/components/search-box.yaml
 required:
   - homePagePath
   - primaryLinks

--- a/source/non-pattern-schema/link.yaml
+++ b/source/non-pattern-schema/link.yaml
@@ -1,16 +1,12 @@
-assets:
-  css: []
-  js: []
-schema:
-  $schema: http://json-schema.org/draft-04/schema#
-  type: object
-  properties:
-    name:
-      type: string
-      minLength: 1
-    url:
-      type: string
-      minLength: 1
-  required:
-    - name
-    - url
+$schema: http://json-schema.org/draft-04/schema#
+type: object
+properties:
+  name:
+    type: string
+    minLength: 1
+  url:
+    type: string
+    minLength: 1
+required:
+  - name
+  - url


### PR DESCRIPTION
We don't and won't use the individual css files, so there's no point generating them.

This also means we can drop the requirement for Compass which is no longer supported, and will avoid the problem where triggering a (Compass-based) css file regeneration while the previous generation was still running caused the css-watch part of the watch process to hard stop, resulting in only a partial watch, and requiring a process restart to restore things.

The result of this PR being merged must be incorporated into https://github.com/elifesciences/patterns-php/pull/637