### PR TITLE
Fix non-js Highlights layout

### DIFF
--- a/assets/sass/patterns/organisms/listing.scss
+++ b/assets/sass/patterns/organisms/listing.scss
@@ -123,7 +123,13 @@ div.listing-list__content {
   @include margin(unquote("0 -#{$totalHighlightsSpacing / 2}"));
 
   .listing-list__item {
-    border: 1px solid #ccc;
+    border: 0 solid #ccc;
+    border-bottom-width: 1px;
+
+    .js & {
+      border-width: 1px;
+    }
+
     @include margin(3, "left");
     @include margin(3, "right");
 

--- a/assets/sass/patterns/organisms/listing.scss
+++ b/assets/sass/patterns/organisms/listing.scss
@@ -127,13 +127,8 @@ div.listing-list__content {
     border-bottom-width: 1px;
     padding-bottom: 1px;
 
-    // Breaks rule of only adding white space underneath. Tightly scoped to the highlights, so shouldn't leak.
-    padding-top: #{$blg-space-extra-small-in-px}px;
-
-    .js & {
-      border-width: 1px;
-      padding-bottom: 0;
-    }
+    // Breaks rule of only adding white space underneath. Tightly scoped to Highlights: shouldn't leak, but be careful.
+    @include blg-spacing("top", "extra-small");
 
     @include margin(3, "left");
     @include margin(3, "right");
@@ -159,11 +154,11 @@ div.listing-list__content {
     white-space: nowrap;
 
     .listing-list__item {
+      border-width: 1px;
       display: inline-block;
       list-style-type: none;
       @include margin(3, "left");
       @include margin(3, "right");
-      @include blg-spacing("top", "extra-small");
       @include padding(12, "left");
       @include padding(12, "right");
 

--- a/assets/sass/patterns/organisms/listing.scss
+++ b/assets/sass/patterns/organisms/listing.scss
@@ -125,6 +125,8 @@ div.listing-list__content {
   .listing-list__item {
     border: 0 solid #ccc;
     border-bottom-width: 1px;
+
+    // Adding extra pixel to account for removal of the top border sustains correct vertical rhythm.
     padding-bottom: 1px;
 
     // Breaks rule of only adding white space underneath. Tightly scoped to Highlights: shouldn't leak, but be careful.
@@ -161,6 +163,7 @@ div.listing-list__content {
       @include margin(3, "right");
       @include padding(12, "left");
       @include padding(12, "right");
+      padding-bottom: 0;
 
       vertical-align: top;
 

--- a/assets/sass/patterns/organisms/listing.scss
+++ b/assets/sass/patterns/organisms/listing.scss
@@ -125,9 +125,11 @@ div.listing-list__content {
   .listing-list__item {
     border: 0 solid #ccc;
     border-bottom-width: 1px;
+    padding-bottom: 1px;
 
     .js & {
       border-width: 1px;
+      padding-bottom: 0;
     }
 
     @include margin(3, "left");

--- a/assets/sass/patterns/organisms/listing.scss
+++ b/assets/sass/patterns/organisms/listing.scss
@@ -127,6 +127,9 @@ div.listing-list__content {
     border-bottom-width: 1px;
     padding-bottom: 1px;
 
+    // Breaks rule of only adding white space underneath. Tightly scoped to the highlights, so shouldn't leak.
+    padding-top: #{$blg-space-extra-small-in-px}px;
+
     .js & {
       border-width: 1px;
       padding-bottom: 0;


### PR DESCRIPTION
For non-js behaviour, this PR turns the layout of the Highlights pattern from
![screenshot 2018-07-12 14 56 13](https://user-images.githubusercontent.com/2893480/42637722-d38ef6d0-85e3-11e8-9cc7-c0530eeb8704.png)
into
![screenshot 2018-07-12 14 56 36](https://user-images.githubusercontent.com/2893480/42637780-f537a822-85e3-11e8-8502-af5df63dc3de.png)

while keeping the vertical rhythm.
