### PR TITLE
Aid display of longer titles in graphical headers

### DIFF
--- a/assets/sass/patterns/atoms/social-media-sharers.scss
+++ b/assets/sass/patterns/atoms/social-media-sharers.scss
@@ -11,7 +11,6 @@
 //  Fill: solid
 
 .social-media-sharers {
-  @include blg-spacing("top", "small", "margin");
   flex-grow: 0;
   flex-basis: 24px;
 }


### PR DESCRIPTION
Removes the 24px margin from the top of the social media sharers block that appears in the content header.

Mitigates the effects reported in https://github.com/elifesciences/issues/issues/4430