### PR TITLE
Popup color fix

### DIFF
--- a/assets/sass/patterns/molecules/article-section.scss
+++ b/assets/sass/patterns/molecules/article-section.scss
@@ -122,7 +122,7 @@ $arrow-size: 5;
     margin: 0;
   }
 
-  .reference:not(.popup__window) a {
+  .reference:not(.popup__content) a {
     color: $color-text;
 
     &:hover {

--- a/assets/sass/patterns/molecules/article-section.scss
+++ b/assets/sass/patterns/molecules/article-section.scss
@@ -122,7 +122,7 @@ $arrow-size: 5;
     margin: 0;
   }
 
-  .reference a {
+  .reference:not(.popup__window) a {
     color: $color-text;
 
     &:hover {


### PR DESCRIPTION
Links in the black-background popup for e.g. references are showing black. This fixes it.