### PR TITLE
Fix flash of dismissed info-bar

### DIFF
--- a/assets/sass/patterns/atoms/info-bars.scss
+++ b/assets/sass/patterns/atoms/info-bars.scss
@@ -77,6 +77,11 @@
 
 .info-bar--dismissible {
 
+  // when js is available, don't show until js has had a chance to hide it
+  .js &:not([data-behaviour-initialised]) {
+    display: none;
+  }
+
   .info-bar__container {
     margin: 0 auto;
     width: 100%;


### PR DESCRIPTION
Fixes the brief flash of the dismissible info bar when it's previously been dismissed, but before the js has completed initialising on the current page load.