### PR TITLE
Add optional secondary links to article download links

### DIFF
--- a/assets/sass/_normalize-overrides.scss
+++ b/assets/sass/_normalize-overrides.scss
@@ -61,7 +61,7 @@ p a:not(.additional-asset__link--download):not(.asset-viewer-inline__download_al
   @include discreet-link();
 }
 
-.article-section__body ul:not(.reference__abstracts) a {
+.article-section__body ul:not(.reference__abstracts) a:not(.article-download-links-list__secondary_link) {
   @include discreet-link();
 }
 

--- a/assets/sass/patterns/molecules/article-download-links-list.scss
+++ b/assets/sass/patterns/molecules/article-download-links-list.scss
@@ -1,5 +1,15 @@
 @import "../../definitions";
 
+.article-download-links-list__link {
+  font-weight: normal;
+}
+
+.article-download-links-list__secondary_link {
+  @include font-size(14);
+  font-family: $font-secondary;
+  color: $color-primary;
+}
+
 .article-download-links-list--js {
   background-color: #fff;
   border: 1px solid #e0e0e0;

--- a/assets/sass/patterns/molecules/article-download-links-list.scss
+++ b/assets/sass/patterns/molecules/article-download-links-list.scss
@@ -8,6 +8,13 @@
   @include font-size(14);
   font-family: $font-secondary;
   color: $color-primary;
+
+  .article-download-links-list--js & {
+    display: block;
+    @include font-size(12);
+    @include padding(24, left);
+    @include margin(6, top);
+  }
 }
 
 .article-download-links-list--js {
@@ -33,7 +40,7 @@
       margin-bottom: 0;
     }
 
-    & li:first-child {
+    & .article-download-links-list__item:first-child {
       border-top-style: none;
     }
 
@@ -44,10 +51,17 @@
     }
   }
 
-  .article-download-links-list__link {
-    display: block;
+  .article-download-links-list__item {
     @include blg-spacing("top", "extra-small");
     @include blg-spacing("bottom", "extra-small");
+
+    dl {
+      margin-bottom: 0;
+    }
+  }
+
+  .article-download-links-list__link {
+    display: block;
     @include padding(24, "left");
     @include padding(24, "right");
     @include menu-typeg();

--- a/source/_patterns/01-molecules/components/article-download-links-list.json
+++ b/source/_patterns/01-molecules/components/article-download-links-list.json
@@ -6,26 +6,32 @@
       "title": "Downloads<span class=\"visuallyhidden\"> (links to download the article or parts of the article as PDF, and in DAR format)</span>",
       "items": [
         {
-          "name": "Article",
-          "url": "#",
-          "attributes": [
-            {
-              "key": "foo",
-              "value": "bar"
-            },
-            {
-              "key": "baz"
-            }
-          ]
+          "primary": {
+            "name": "Article",
+            "url": "#",
+            "attributes": [
+              {
+                "key": "foo",
+                "value": "bar"
+              },
+              {
+                "key": "baz"
+              }
+            ]
+          }
         },
         {
-          "name": "Figures",
-          "url": "#"
+          "primary": {
+            "name": "Figures",
+            "url": "#"
+          }
         },
         {
-          "name": "Executable DAR",
-          "url": "#darLink",
-          "secondaryLink": {
+          "primary": {
+            "name": "Executable DAR",
+            "url": "#darLink"
+          },
+          "secondary": {
             "name": "Learn more about DAR",
             "url": "#secondaryLink"
           }
@@ -36,28 +42,40 @@
       "title": "Download citations<span class=\"visuallyhidden\"> (links to download the citations from this article in formats compatible with various reference manager tools)</span>",
       "items": [
         {
-          "name": "BibTex",
-          "url": "#"
+          "primary": {
+            "name": "BibTex",
+            "url": "#"
+          }
         },
         {
-          "name": "EndNote",
-          "url": "#"
+          "primary": {
+            "name": "EndNote",
+            "url": "#"
+          }
         },
         {
-          "name": "EndNote 8",
-          "url": "#"
+          "primary": {
+            "name": "EndNote 8",
+            "url": "#"
+          }
         },
         {
-          "name": "Refworks Tagged",
-          "url": "#"
+          "primary": {
+            "name": "Refworks Tagged",
+            "url": "#"
+          }
         },
         {
-          "name": "RIS",
-          "url": "#"
+          "primary": {
+            "name": "RIS",
+            "url": "#"
+          }
         },
         {
-          "name": "Medlars",
-          "url": "#"
+          "primary": {
+            "name": "Medlars",
+            "url": "#"
+          }
         }
       ]
     },
@@ -65,20 +83,28 @@
       "title": "Open citations<span class=\"visuallyhidden\"> (links to open the citations from this article in various online reference manager services)</span>",
       "items": [
         {
-          "name": "Mendeley",
-          "url": "#"
+          "primary": {
+            "name": "Mendeley",
+            "url": "#"
+          }
         },
         {
-          "name": "ReadCube",
-          "url": "#"
+          "primary": {
+            "name": "ReadCube",
+            "url": "#"
+          }
         },
         {
-          "name": "Papers App",
-          "url": "#"
+          "primary": {
+            "name": "Papers App",
+            "url": "#"
+          }
         },
         {
-          "name": "CiteUlike",
-          "url": "#"
+          "primary": {
+            "name": "CiteUlike",
+            "url": "#"
+          }
         }
       ]
     }

--- a/source/_patterns/01-molecules/components/article-download-links-list.json
+++ b/source/_patterns/01-molecules/components/article-download-links-list.json
@@ -3,7 +3,7 @@
   "description": "A three part list of links to download the article, or parts of the article, in various formats.",
   "groups": [
     {
-      "title": "Downloads<span class=\"visuallyhidden\"> (links to download the article or parts of the article as PDF)</span>",
+      "title": "Downloads<span class=\"visuallyhidden\"> (links to download the article or parts of the article as PDF, and in DAR format)</span>",
       "items": [
         {
           "name": "Article",
@@ -21,6 +21,14 @@
         {
           "name": "Figures",
           "url": "#"
+        },
+        {
+          "name": "Executable DAR",
+          "url": "#darLink",
+          "secondaryLink": {
+            "name": "Learn more about DAR",
+            "url": "#secondaryLink"
+          }
         }
       ]
     },

--- a/source/_patterns/01-molecules/components/article-download-links-list.mustache
+++ b/source/_patterns/01-molecules/components/article-download-links-list.mustache
@@ -16,7 +16,7 @@
                     >{{{name}}}</a>
               {{#secondaryLink}}
                 </dt>
-                <dd><a href="{{url}}">{{{name}}}</a></dd>
+                <dd><a href="{{url}}" class="article-download-links-list__secondary_link">{{{name}}}</a></dd>
               </dl>
             {{/secondaryLink}}
           </li>

--- a/source/_patterns/01-molecules/components/article-download-links-list.mustache
+++ b/source/_patterns/01-molecules/components/article-download-links-list.mustache
@@ -6,19 +6,25 @@
     <ul class="article-download-list">
       {{#items}}
           <li class="article-download-links-list__item">
-            {{#secondaryLink}}
+
+            {{#secondary}}
               <dl>
                 <dt>
-            {{/secondaryLink}}
-                    <a href="{{url}}"
+            {{/secondary}}
+
+            {{#primary}}
+              <a href="{{url}}"
                        class="article-download-links-list__link"
                        {{#attributes}}data-{{key}}{{#value}}="{{value}}"{{/value}}{{/attributes}}
                     >{{{name}}}</a>
-              {{#secondaryLink}}
+            {{/primary}}
+
+            {{#secondary}}
                 </dt>
                 <dd><a href="{{url}}" class="article-download-links-list__secondary_link">{{{name}}}</a></dd>
               </dl>
-            {{/secondaryLink}}
+            {{/secondary}}
+
           </li>
       {{/items}}
     </ul>

--- a/source/_patterns/01-molecules/components/article-download-links-list.mustache
+++ b/source/_patterns/01-molecules/components/article-download-links-list.mustache
@@ -5,13 +5,21 @@
     <h3 class="article-download-links-list__heading">{{{title}}}</h3>
     <ul class="article-download-list">
       {{#items}}
-       <li><a href="{{url}}" class="article-download-links-list__link"
-
-       {{#attributes}}
-         data-{{key}}{{#value}}="{{value}}"{{/value}}
-       {{/attributes}}
-
-       >{{{name}}}</a></li>
+          <li>
+            {{#secondaryLink}}
+              <dl>
+                <dt>
+            {{/secondaryLink}}
+                    <a href="{{url}}"
+                       class="article-download-links-list__link"
+                       {{#attributes}}data-{{key}}{{#value}}="{{value}}"{{/value}}{{/attributes}}
+                    >{{{name}}}</a>
+              {{#secondaryLink}}
+                </dt>
+                <dd><a href="{{url}}">{{{name}}}</a></dd>
+              </dl>
+            {{/secondaryLink}}
+          </li>
       {{/items}}
     </ul>
   {{/groups}}

--- a/source/_patterns/01-molecules/components/article-download-links-list.mustache
+++ b/source/_patterns/01-molecules/components/article-download-links-list.mustache
@@ -5,7 +5,7 @@
     <h3 class="article-download-links-list__heading">{{{title}}}</h3>
     <ul class="article-download-list">
       {{#items}}
-          <li>
+          <li class="article-download-links-list__item">
             {{#secondaryLink}}
               <dl>
                 <dt>

--- a/source/_patterns/01-molecules/components/article-download-links-list.yaml
+++ b/source/_patterns/01-molecules/components/article-download-links-list.yaml
@@ -22,25 +22,7 @@ properties:
           items:
             type: object
             properties:
-              name:
-                type: string
-                minLength: 1
-              url:
-                type: string
-                minLength: 1
-              attributes:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    key:
-                      type: string
-                      minLength: 1
-                    value:
-                      type: string
-                  required:
-                    - key
-              secondaryLink:
+              primary:
                 type: object
                 properties:
                   name:
@@ -49,12 +31,41 @@ properties:
                   url:
                     type: string
                     minLength: 1
-                required:
-                  - name
-                  - url
+                  attributes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          type: string
+                          minLength: 1
+                        value:
+                          type: string
+                      required:
+                        - key
+              secondary:
+                type: object
+                properties:
+                  name:
+                    type: string
+                    minLength: 1
+                  url:
+                    type: string
+                    minLength: 1
+                  attributes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          type: string
+                          minLength: 1
+                        value:
+                          type: string
+                      required:
+                        - key
             required:
-              - name
-              - url
+              - primary
       required:
         - title
         - items

--- a/source/_patterns/01-molecules/components/article-download-links-list.yaml
+++ b/source/_patterns/01-molecules/components/article-download-links-list.yaml
@@ -65,8 +65,6 @@ properties:
                           minLength: 1
                         value:
                           type: string
-                      required:
-                        - key
                 required:
                   - name
                   - url

--- a/source/_patterns/01-molecules/components/article-download-links-list.yaml
+++ b/source/_patterns/01-molecules/components/article-download-links-list.yaml
@@ -40,6 +40,18 @@ properties:
                       type: string
                   required:
                     - key
+              secondaryLink:
+                type: object
+                properties:
+                  name:
+                    type: string
+                    minLength: 1
+                  url:
+                    type: string
+                    minLength: 1
+                required:
+                  - name
+                  - url
             required:
               - name
               - url

--- a/source/_patterns/01-molecules/components/article-download-links-list.yaml
+++ b/source/_patterns/01-molecules/components/article-download-links-list.yaml
@@ -43,6 +43,9 @@ properties:
                           type: string
                       required:
                         - key
+                required:
+                  - name
+                  - url
               secondary:
                 type: object
                 properties:
@@ -64,6 +67,9 @@ properties:
                           type: string
                       required:
                         - key
+                required:
+                  - name
+                  - url
             required:
               - primary
       required:

--- a/source/_patterns/01-molecules/components/article-download-links-list.yaml
+++ b/source/_patterns/01-molecules/components/article-download-links-list.yaml
@@ -55,16 +55,6 @@ properties:
                   url:
                     type: string
                     minLength: 1
-                  attributes:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        key:
-                          type: string
-                          minLength: 1
-                        value:
-                          type: string
                 required:
                   - name
                   - url

--- a/source/_patterns/04-pages/article--research.json
+++ b/source/_patterns/04-pages/article--research.json
@@ -574,17 +574,23 @@
           "title": "Downloads<span class=\"visuallyhidden\"> (links to download the article or parts of the article as PDF, and in DAR format)</span>",
           "items": [
             {
-              "name": "Article",
-              "url": "#"
+              "primary": {
+                "name": "Article",
+                "url": "#"
+              }
             },
             {
-              "name": "Figures",
-              "url": "#"
+              "primary": {
+                "name": "Figures",
+                "url": "#"
+              }
             },
             {
-              "name": "Executable DAR",
-              "url": "#darLink",
-              "secondaryLink": {
+              "primary": {
+                "name": "Executable DAR",
+                "url": "#darLink"
+              },
+              "secondary": {
                 "name": "Learn more about DAR",
                 "url": "#secondaryLink"
               }
@@ -595,12 +601,16 @@
           "title": "Download citations<span class=\"visuallyhidden\"> (links to download the citations from this article in formats compatible with various reference manager tools)</span>",
           "items": [
             {
-              "name": "BibTex",
-              "url": "#"
+              "primary": {
+                "name": "BibTex",
+                "url": "#"
+              }
             },
             {
-              "name": "RIS",
-              "url": "#"
+              "primary": {
+                "name": "RIS",
+                "url": "#"
+              }
             }
           ]
         },
@@ -608,20 +618,28 @@
           "title": "Open citations<span class=\"visuallyhidden\"> (links to open the citations from this article in various online reference manager services)</span>",
           "items": [
             {
-              "name": "Mendeley",
-              "url": "#"
+              "primary": {
+                "name": "Mendeley",
+                "url": "#"
+              }
             },
             {
-              "name": "ReadCube",
-              "url": "#"
+              "primary": {
+                "name": "ReadCube",
+                "url": "#"
+              }
             },
             {
-              "name": "Papers App",
-              "url": "#"
+              "primary": {
+                "name": "Papers App",
+                "url": "#"
+              }
             },
             {
-              "name": "CiteUlike",
-              "url": "#"
+              "primary": {
+                "name": "CiteUlike",
+                "url": "#"
+              }
             }
           ]
         }

--- a/source/_patterns/04-pages/article--research.json
+++ b/source/_patterns/04-pages/article--research.json
@@ -571,7 +571,7 @@
       "description": "A three part list of links to download the article, or parts of the article, in various formats.",
       "groups": [
         {
-          "title": "Downloads<span class=\"visuallyhidden\"> (links to download the article or parts of the article as PDF)</span>",
+          "title": "Downloads<span class=\"visuallyhidden\"> (links to download the article or parts of the article as PDF, and in DAR format)</span>",
           "items": [
             {
               "name": "Article",
@@ -580,6 +580,14 @@
             {
               "name": "Figures",
               "url": "#"
+            },
+            {
+              "name": "Executable DAR",
+              "url": "#darLink",
+              "secondaryLink": {
+                "name": "Learn more about DAR",
+                "url": "#secondaryLink"
+              }
             }
           ]
         },

--- a/test/articledownloadlinkslist.html
+++ b/test/articledownloadlinkslist.html
@@ -27,33 +27,71 @@
 
 
 
-    <div data-behaviour="ArticleDownloadLinksList" id="articleDownloadLinksList">
+    <div data-behaviour="ArticleDownloadLinksList" id="download" aria-labelledby="download-label">
+      <div class="visuallyhidden"><span id="download-label">A three part list of links to download the article, or parts of the article, in various formats.</span></div>
 
       <h3 class="article-download-links-list__heading">Downloads<span class="visuallyhidden"> (links to download the article or parts of the article as PDF)</span></h3>
       <ul class="article-download-list">
-        <li><a href="#" class="article-download-links-list__link">Article</a></li>
-        <li><a href="#" class="article-download-links-list__link">Figures</a></li>
-      </ul>
+        <li><a href="#" class="article-download-links-list__link"
 
+               data-foo="bar"
+               data-baz
+
+        >Article</a></li>
+        <li><a href="#" class="article-download-links-list__link"
+
+
+        >Figures</a></li>
+      </ul>
       <h3 class="article-download-links-list__heading">Download citations<span class="visuallyhidden"> (links to download the citations from this article in formats compatible with various reference manager tools)</span></h3>
-      <ul class="article-download-citations-list">
-        <li><a href="#" class="article-download-links-list__link">BibTex</a></li>
-        <li><a href="#" class="article-download-links-list__link">EndNote</a></li>
-        <li><a href="#" class="article-download-links-list__link">EndNote 8</a></li>
-        <li><a href="#" class="article-download-links-list__link">Refworks Tagged</a></li>
-        <li><a href="#" class="article-download-links-list__link">RIS</a></li>
-        <li><a href="#" class="article-download-links-list__link">Medlars</a></li>
-      </ul>
+      <ul class="article-download-list">
+        <li><a href="#" class="article-download-links-list__link"
 
+
+        >BibTex</a></li>
+        <li><a href="#" class="article-download-links-list__link"
+
+
+        >EndNote</a></li>
+        <li><a href="#" class="article-download-links-list__link"
+
+
+        >EndNote 8</a></li>
+        <li><a href="#" class="article-download-links-list__link"
+
+
+        >Refworks Tagged</a></li>
+        <li><a href="#" class="article-download-links-list__link"
+
+
+        >RIS</a></li>
+        <li><a href="#" class="article-download-links-list__link"
+
+
+        >Medlars</a></li>
+      </ul>
       <h3 class="article-download-links-list__heading">Open citations<span class="visuallyhidden"> (links to open the citations from this article in various online reference manager services)</span></h3>
-      <ul>
-        <li><a href="#" class="article-download-links-list__link">Mendeley</a></li>
-        <li><a href="#" class="article-download-links-list__link">ReadCube</a></li>
-        <li><a href="#" class="article-download-links-list__link">Papers App</a></li>
-        <li><a href="#" class="article-download-links-list__link">CiteUlike</a></li>
+      <ul class="article-download-list">
+        <li><a href="#" class="article-download-links-list__link"
+
+
+        >Mendeley</a></li>
+        <li><a href="#" class="article-download-links-list__link"
+
+
+        >ReadCube</a></li>
+        <li><a href="#" class="article-download-links-list__link"
+
+
+        >Papers App</a></li>
+        <li><a href="#" class="article-download-links-list__link"
+
+
+        >CiteUlike</a></li>
       </ul>
 
     </div>
+
     <!--
       Load test code
     -->


### PR DESCRIPTION
Motivation: to allow a DAR download link to have a proximal explanatory link.