### PR TITLE
Add optional title attribute to iframe

### DIFF
--- a/source/_patterns/00-atoms/components/iframe.mustache
+++ b/source/_patterns/00-atoms/components/iframe.mustache
@@ -1,3 +1,3 @@
 <div class="iframe" style="padding-bottom: {{paddingBottom}}%">
-    <iframe src="{{src}}" {{#allowFullScreen}}allowfullscreen{{/allowFullScreen}}></iframe>
+    <iframe src="{{src}}"{{#title}} title="{{{.}}}"{{/title}} {{#allowFullScreen}}allowfullscreen{{/allowFullScreen}}></iframe>
 </div>

--- a/source/_patterns/00-atoms/components/iframe.yaml
+++ b/source/_patterns/00-atoms/components/iframe.yaml
@@ -4,6 +4,9 @@ properties:
   src:
     type: string
     minLength: 1
+  title:
+    type: string
+    minLength: 1
   allowFullScreen:
     type: boolean
     default: false

--- a/source/_patterns/00-atoms/components/iframe~with-title.json
+++ b/source/_patterns/00-atoms/components/iframe~with-title.json
@@ -1,0 +1,5 @@
+{
+  "src": "https://www.youtube.com/embed/6j0jRXPvpCE",
+  "title": "What makes eLife paper webinar",
+  "paddingBottom": 56.25
+}


### PR DESCRIPTION
This will allow us to set a title attribute for embedded content that uses an iframe. Currently, this is being used for youtube videos. We want to ensure that it is an available attribute for new embedded content that we are introducing but it would be great to introduce it for existing uses as well.