### PR TITLE
Image credit spacing

### DIFF
--- a/assets/sass/layout/_grid.scss
+++ b/assets/sass/layout/_grid.scss
@@ -115,7 +115,7 @@
   }
 
   .content-header-simple + &.wrapper--listing,
-  .content-header-image-wrapper + &.wrapper--listing {
+  .content-header-image-wrapper:not(.content-header-image-wrapper--with-credit-overlay) + &.wrapper--listing {
     padding-top: 0;
   }
 

--- a/source/_patterns/02-organisms/content-headers/content-header.mustache
+++ b/source/_patterns/02-organisms/content-headers/content-header.mustache
@@ -1,5 +1,5 @@
 {{#image}}
-<div class="content-header-image-wrapper{{^image.creditOverlay}}{{^image.credit}} content-header-image-wrapper--no-credit{{/image.credit}}{{/image.creditOverlay}}">
+  <div class="content-header-image-wrapper{{#image.creditOverlay}} content-header-image-wrapper--with-credit-overlay{{/image.creditOverlay}} {{^image.creditOverlay}}{{^image.credit}} content-header-image-wrapper--no-credit{{/image.credit}}{{/image.creditOverlay}}">
 {{/image}}
   <header
     class="content-header {{#image}}content-header--image content-header--header{{/image}} {{^image}}wrapper {{#header.possible}}content-header--header{{/header.possible}}{{/image}} {{#socialMediaSharers}}content-header--has-social-media-sharers{{/socialMediaSharers}} {{#header.hasProfile}}content-header--has-profile{{/header.hasProfile}} clearfix"

--- a/source/_patterns/04-pages/collection~image-credit-overlay.json
+++ b/source/_patterns/04-pages/collection~image-credit-overlay.json
@@ -160,7 +160,12 @@
     "image": {
       "fallback": {
         "defaultPath": "https://unsplash.it/1114/336"
-      }
+      },
+      "credit": {
+        "text": "I haz image credit <a href=\"#\">with a link</a>.",
+        "elementId": "iAmTheIdOfTheImageCreditElement"
+      },
+      "creditOverlay": true
     },
     "meta": {
       "url": "#",

--- a/source/_patterns/04-pages/collection~image-credit.json
+++ b/source/_patterns/04-pages/collection~image-credit.json
@@ -160,6 +160,10 @@
     "image": {
       "fallback": {
         "defaultPath": "https://unsplash.it/1114/336"
+      },
+      "credit": {
+        "text": "I haz image credit <a href=\"#\">with a link</a>.",
+        "elementId": "iAmTheIdOfTheImageCreditElement"
       }
     },
     "meta": {


### PR DESCRIPTION
Fixes the problem where the spacing below an image-backed content header is too tight on a following listing.