### PR TITLE
fix: side-by-side menu option no longer appearing on articles

### DIFF
--- a/source/_patterns/01-molecules/navigation/view-selector.mustache
+++ b/source/_patterns/01-molecules/navigation/view-selector.mustache
@@ -15,7 +15,7 @@
       </li>
     {{/otherLinks}}
 
-    <li class="view-selector__divider"></li>
+    <li class="view-selector__list-item view-selector__divider"></li>
 
     {{#jumpLinks}}
       {{#links}}


### PR DESCRIPTION
Issue was caused by the way the code tries to determine where to insert the option in the menu. Adding a class to the divider now ensures that the selector returns a valid element and hence the menu option is inserted.

This fixes elifesciences/issues#6062