### PR TITLE
fix: npm package published by ci is empty

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   ],
   "style": "source/assets/css/all.css",
   "scripts": {
-    "prepare": "gulp"
+    "prepublish": "gulp"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
We run version 8.x of node on the jenkins build nodes, and hence the `prepare` script is not supported in that version. As such, I've switched to `prepublish` which is supported on the version we use.

This fixes elifesciences/issues#6076