### PR TITLE
Add CSS to add backup for image attribution

### DIFF
--- a/assets/sass/patterns/organisms/carousel.scss
+++ b/assets/sass/patterns/organisms/carousel.scss
@@ -35,6 +35,10 @@
 
 .carousel__image-credit--overlay {
   @include image-credit-overlay();
+  max-width: 270px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .js {


### PR DESCRIPTION
This is a backup in case the attribution length does not get caught on the back end.