### PR TITLE
fix: podcast duration test failing due to missing content

### DIFF
--- a/source/_patterns/04-pages/podcast.json
+++ b/source/_patterns/04-pages/podcast.json
@@ -146,7 +146,7 @@
        "url": "#",
        "text": "Podcast"
      },
-     "download": "https://nakeddiscovery.com/download/audio/eLife_Podcast_11.17.mp3",
+     "download": "https://www.thenakedscientists.com/sites/default/files/media/podcasts/episodes/eLife_Podcast_11.17.mp3",
      "image": {
        "fallback": {
          "defaultPath": "https://unsplash.it/1114/336"
@@ -156,7 +156,7 @@
        "title": "Episode 21",
        "episodeNumber": 21,
        "sources":[
-         { "src": "https://nakeddiscovery.com/download/audio/eLife_Podcast_11.17.mp3",
+         { "src": "https://www.thenakedscientists.com/sites/default/files/media/podcasts/episodes/eLife_Podcast_11.17.mp3",
            "mediaType": {
              "forMachine": "audio/mp3",
              "forHuman": "mp3"

--- a/test-selenium/podcast.spec.js
+++ b/test-selenium/podcast.spec.js
@@ -1,8 +1,7 @@
 let chai = require('chai');
 let expect = chai.expect;
 
-// FIXME Investigate and fix this test which suddenly stopped working (see elifesciences/issues#6362).
-describe.skip('A Podcast page', function() {
+describe('A Podcast page', function() {
   it('should have the right title', function () {
     browser.url('/patterns/04-pages-podcast/04-pages-podcast.html');
   });


### PR DESCRIPTION
This fixes elifesciences/issues#6362