### PR TITLE
experiment: reproducible build system using docker and make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+
+PROJECT := $(notdir $(CURDIR))
+NODE_VERSION ?= boron
+PHP_VERSION ?= 7.3-fpm
+
+SOURCES = $(wildcard source/**/*) $(wildcard assets/**/*)
+
+.PHONY: start clean distclean test
+
+.DEFAULT_GOAL := start
+
+distclean: clean
+	@rm -rf node_modules
+
+clean:
+	@rm -rf public
+
+node_modules: package.json
+	docker run -it --rm -v $(CURDIR):/$(PROJECT):rw -w=/$(PROJECT) node:$(NODE_VERSION) npm install
+
+public: node_modules $(SOURCES)
+	@mkdir -p $(CURDIR)/public
+	@cp -r ./core/styleguide $(CURDIR)/public/
+	@docker run -it --rm -v $(CURDIR):/$(PROJECT):rw -w=/$(PROJECT) node:$(NODE_VERSION) ./node_modules/.bin/gulp
+	@docker run -it --rm -v $(CURDIR):/$(PROJECT):rw -w=/$(PROJECT) php:$(PHP_VERSION) php ./core/builder.php -g
+
+start: public
+	@docker run -it --rm -p 8080:8080 -v $(CURDIR):/$(PROJECT):ro -w=/$(PROJECT)/public php:$(PHP_VERSION) php -S 0.0.0.0:8080

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ NODE_VERSION ?= boron
 PHP_VERSION ?= 7.3-fpm
 
 # Source files that when changed should trigger a rebuild.
-SOURCES := $(wildcard source/**/*) $(wildcard assets/**/*)
+SOURCES := $(wildcard assets/**/*) $(wildcard source/**/*)
 
 # Targets that don't result in output of the same name.
 .PHONY: start \
@@ -21,7 +21,7 @@ distclean: clean
 
 # Cleans build output
 clean:
-	@rm -rf public
+	@rm -rf public source/assets
 
 # Install Node.js dependencies if either, the node_modules directory is not present or package.json has changed.
 node_modules: package.json

--- a/Makefile
+++ b/Makefile
@@ -3,26 +3,37 @@ PROJECT := $(notdir $(CURDIR))
 NODE_VERSION ?= boron
 PHP_VERSION ?= 7.3-fpm
 
-SOURCES = $(wildcard source/**/*) $(wildcard assets/**/*)
+# Source files that when changed should trigger a rebuild.
+SOURCES := $(wildcard source/**/*) $(wildcard assets/**/*)
 
-.PHONY: start clean distclean test
+# Targets that don't result in output of the same name.
+.PHONY: start \
+        clean \
+				distclean \
+				test
 
+# When no target is specified, the default target to run.
 .DEFAULT_GOAL := start
 
+# Cleans build output and local dependencies
 distclean: clean
 	@rm -rf node_modules
 
+# Cleans build output
 clean:
 	@rm -rf public
 
+# Install Node.js dependencies if either, the node_modules directory is not present or package.json has changed.
 node_modules: package.json
 	docker run -it --rm -v $(CURDIR):/$(PROJECT):rw -w=/$(PROJECT) node:$(NODE_VERSION) npm install
 
+# Builds the patterns, and pattern-lab static site.
 public: node_modules $(SOURCES)
 	@mkdir -p $(CURDIR)/public
 	@cp -r ./core/styleguide $(CURDIR)/public/
 	@docker run -it --rm -v $(CURDIR):/$(PROJECT):rw -w=/$(PROJECT) node:$(NODE_VERSION) ./node_modules/.bin/gulp
 	@docker run -it --rm -v $(CURDIR):/$(PROJECT):rw -w=/$(PROJECT) php:$(PHP_VERSION) php ./core/builder.php -g
 
+# Builds and runs the application on localhost:8080.
 start: public
 	@docker run -it --rm -p 8080:8080 -v $(CURDIR):/$(PROJECT):ro -w=/$(PROJECT)/public php:$(PHP_VERSION) php -S 0.0.0.0:8080

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 
 PROJECT := $(notdir $(CURDIR))
 NODE_VERSION ?= boron
-PHP_VERSION ?= 7.3-fpm
+PHP_VERSION ?= 7.3-cli
+COMPOSER_VERSION ?= 1.6.4
+PORT ?= 8080
 
 # Source files that when changed should trigger a rebuild.
 SOURCES := $(wildcard assets/**/*) $(wildcard source/**/*)
@@ -10,7 +12,8 @@ SOURCES := $(wildcard assets/**/*) $(wildcard source/**/*)
 .PHONY: start \
         clean \
 				distclean \
-				test
+				test \
+				validate
 
 # When no target is specified, the default target to run.
 .DEFAULT_GOAL := start
@@ -27,6 +30,10 @@ clean:
 node_modules: package.json
 	docker run -it --rm -v $(CURDIR):/$(PROJECT):rw -w=/$(PROJECT) node:$(NODE_VERSION) npm install
 
+# Install PHP dependencies if, the vendor directory is not present or if composer.json or composer.lock have changed. 
+vendor: composer.json composer.lock
+	@docker run -it --rm -v $(CURDIR):/$(PROJECT):rw -w=/$(PROJECT) composer:$(COMPOSER_VERSION) composer --no-interaction install --ignore-platform-reqs --classmap-authoritative --no-suggest --prefer-dist
+
 # Builds the patterns, and pattern-lab static site.
 public: node_modules $(SOURCES)
 	@mkdir -p $(CURDIR)/public
@@ -34,6 +41,19 @@ public: node_modules $(SOURCES)
 	@docker run -it --rm -v $(CURDIR):/$(PROJECT):rw -w=/$(PROJECT) node:$(NODE_VERSION) ./node_modules/.bin/gulp
 	@docker run -it --rm -v $(CURDIR):/$(PROJECT):rw -w=/$(PROJECT) php:$(PHP_VERSION) php ./core/builder.php -g
 
+# Runs the unit test suite
+unit: public
+	@docker run -it --rm -v $(CURDIR):/$(PROJECT):rw -w=/$(PROJECT) node:$(NODE_VERSION) ./node_modules/.bin/gulp test:unit
+
+# Runs the schema validator
+validate: vendor
+	@docker run -it --rm -v $(CURDIR):/$(PROJECT):rw -w=/$(PROJECT) php:$(PHP_VERSION) php bin/validate
+
 # Builds and runs the application on localhost:8080.
 start: public
-	@docker run -it --rm -p 8080:8080 -v $(CURDIR):/$(PROJECT):ro -w=/$(PROJECT)/public php:$(PHP_VERSION) php -S 0.0.0.0:8080
+	@docker run --rm -d --name $(PROJECT) -p $(PORT):80 -v $(CURDIR)/public:/usr/share/nginx/html/:ro nginx:alpine
+	@echo "$(PROJECT) listening on 'http://localhost:$(PORT)'"
+
+# If running, stops the container.
+stop:
+	@-docker stop $(PROJECT)


### PR DESCRIPTION
An experiment to update the projects tooling to not rely on a series of cascading containers (which really break the developer experience) and instead replace it with something that is platform independent and will always build the project using the same tools and code. 
This specific experiment looks at using docker, but only official containers, and using make to ensure that only what is needed is built. The goal is, can a developer simply checkout the codebase and type `make` and get a local instance of pattern-library running on their machine, regardless of what the host operating system is.
 
- [x] Initial target, `start` that can build and start the project from scratch available on http://localhost:8080.
- [ ] Additional target, `test`, that runs both the unit and ux test suites, with all tests passing.
- [ ] Additional target, `dev`, that runs in watch mode allowing a developer to make changes without needing to rebuild.
- [ ] Additional target, `dist`, that builds a publishable container with the specified tag.