### PR TITLE
Remove carousel followup

### DIFF
--- a/assets/js/components/Highlights.js
+++ b/assets/js/components/Highlights.js
@@ -127,7 +127,7 @@ module.exports = class Highlights {
     this.margin = this.calculateMargin() * 2;
 
     // Update some things.
-    this.contentWidth = window.getComputedStyle(this.$elm).width.match(/([0-9\.]+)px/)[1];
+    this.carouselWidth = window.getComputedStyle(this.$elm).width.match(/([0-9\.]+)px/)[1];
     this.setCurrentSlide(this.currentSlide);
 
     // Render view.
@@ -146,12 +146,12 @@ module.exports = class Highlights {
         this.$nextBtn,
         this.$prevBtn,
         this.currentSlide,
-        this.contentWidth,
+        this.carouselWidth,
         this.inView
     );
   }
 
-  render($el, $nextButton, $prevButton, thisSlide, contentWidth, inView) {
+  render($el, $nextButton, $prevButton, thisSlide, carouselWidth, inView) {
     if (this.isFirstSlide()) {
       $prevButton.classList.add('hidden');
     } else {
@@ -167,8 +167,8 @@ module.exports = class Highlights {
     const numOfMargins = inView - 1;
     const totalMargins = numOfMargins * this.margin;
 
-    // Slide width = Content width - margins / number in view
-    const slideWidth = (contentWidth - totalMargins) / inView;
+    // Slide width = Carousel width - margins / number in view
+    const slideWidth = (carouselWidth - totalMargins) / inView;
 
     // Slide offset = Slide width plus margin
     const slideOffset = slideWidth + this.margin;

--- a/source/_patterns/01-molecules/components/meta-journal.mustache
+++ b/source/_patterns/01-molecules/components/meta-journal.mustache
@@ -1,7 +1,7 @@
 <div class="meta">
 
   {{#url}}
-    <a class="meta__type" href="{{url}}" {{#carouselItem}}tabindex="-1"{{/carouselItem}}>{{{text}}}</a>
+    <a class="meta__type" href="{{url}}">{{{text}}}</a>
   {{/url}}
 
   {{#date}}

--- a/source/_patterns/01-molecules/components/meta-journal.yaml
+++ b/source/_patterns/01-molecules/components/meta-journal.yaml
@@ -8,10 +8,6 @@ properties:
       - type: boolean
         enum:
           - false
-  carouselItem:
-    type: boolean
-    enum:
-      - true
   text:
     type: string
     minLength: 1

--- a/source/_patterns/01-molecules/components/meta.mustache
+++ b/source/_patterns/01-molecules/components/meta.mustache
@@ -1,7 +1,7 @@
 <div class="meta">
 
   {{#url}}
-    <a class="meta__type" href="{{url}}" {{#carouselItem}}tabindex="-1"{{/carouselItem}}>{{{text}}}</a>
+    <a class="meta__type" href="{{url}}">{{{text}}}</a>
   {{/url}}
 
   {{^url}}

--- a/source/_patterns/01-molecules/components/meta.yaml
+++ b/source/_patterns/01-molecules/components/meta.yaml
@@ -8,10 +8,6 @@ properties:
       - type: boolean
         enum:
           - false
-  carouselItem:
-    type: boolean
-    enum:
-      - true
   text:
     type: string
     minLength: 1


### PR DESCRIPTION
I wasn't happy with the changes to Highlights.js. listings with teasers as highlights is a carousel so we should restore the mention of carousel and this reflects in the use of carouselItem for listing teaser items. I did find that the use of carouselItem in meta and meta-journal is no longer needed. 