### PR TITLE
Fix position issue of download link in Chrome

### DIFF
--- a/assets/sass/patterns/organisms/content-header.scss
+++ b/assets/sass/patterns/organisms/content-header.scss
@@ -528,7 +528,6 @@ $iconlist: cc oa;
 .side-section-wrapper__download_link {
   grid-row: 1;
   grid-column-end: 4;
-  justify-self: end;
   order: 3;
 
   @media only all and (min-width: #{get-rem-from-px($bkpt-site--wide)}em) {


### PR DESCRIPTION
This is purely a bug issue for Chrome. Looks ok in other browsers. https://github.com/elifesciences/issues/issues/9154